### PR TITLE
Fix codespell setup: keep config in pyproject.toml and do not sub-select folders

### DIFF
--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -372,7 +372,7 @@ def cubids_group():
 
 
 def cubids_apply():
-    ''' Command Line Interface funciton for applying the tsv changes.'''
+    ''' Command Line Interface function for applying the tsv changes.'''
 
     parser = argparse.ArgumentParser(
         description="cubids-apply: apply the changes specified in a tsv "
@@ -508,7 +508,7 @@ def cubids_apply():
 
 
 def cubids_datalad_save():
-    ''' Command Line Interfcae function for performing datalad save.'''
+    ''' Command Line Interface function for performing datalad save.'''
 
     parser = argparse.ArgumentParser(
         description="cubids-datalad-save: perform a DataLad save on a BIDS "
@@ -614,7 +614,7 @@ def cubids_copy_exemplars():
                         type=Path,
                         action='store',
                         help='absolute path to the .tsv file that lists one '
-                        'subject from each Acqusition Group '
+                        'subject from each Acquisition Group '
                         '(*_AcqGrouping.tsv from the cubids-group output)')
     parser.add_argument('--use-datalad',
                         action='store_true',

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -211,7 +211,7 @@ class CuBIDS(object):
         and generates the new tsv files.
 
         This function looks at the RenameKeyGroup and MergeInto
-        columns and modifies the bids datset according to the
+        columns and modifies the bids dataset according to the
         specified changs.
 
         Parameters:
@@ -547,12 +547,12 @@ class CuBIDS(object):
         -----------
             exemplars_dir: str
                 path to the directory that will contain one subject
-                from each Acqusition Gorup (*_AcqGrouping.tsv)
+                from each Acquisition Group (*_AcqGrouping.tsv)
                 example path: /Users/Covitz/tsvs/CCNP_Acq_Groups/
 
             exemplars_tsv: str
                 path to the .tsv file that lists one subject
-                from each Acqusition Group (*_AcqGrouping.tsv
+                from each Acquisition Group (*_AcqGrouping.tsv
                 from the cubids-group output)
                 example path: /Users/Covitz/tsvs/CCNP_Acq_Grouping.tsv
         """
@@ -602,7 +602,7 @@ class CuBIDS(object):
             scans_txt: str
                 path to the .txt file that lists the scans
                 you want to be deleted from the dataset, along
-                with thier associations.
+                with their associations.
                 example path: /Users/Covitz/CCNP/scans_to_delete.txt
         """
 
@@ -735,7 +735,7 @@ class CuBIDS(object):
             print("Not running any association removals")
 
     def get_nifti_associations(self, nifti):
-        # get all assocation files of a nifti image
+        # get all association files of a nifti image
         no_ext_file = str(nifti).split('/')[-1].split('.')[0]
         associations = []
         for path in Path(self.path).rglob("sub-*/**/*.*"):
@@ -836,7 +836,7 @@ class CuBIDS(object):
         if ret == "erroneous sidecar found":
             return "erroneous sidecar found"
 
-        # add modality to the retun tuple
+        # add modality to the return tuple
         l_ret = list(ret)
         l_ret.append(modality)
         tup_ret = tuple(l_ret)

--- a/cubids/metadata_merge.py
+++ b/cubids/metadata_merge.py
@@ -12,7 +12,7 @@ DIRECT_IMAGING_PARAMS = IMAGING_PARAMS - set(["NSliceTimes"])
 def check_merging_operations(action_tsv, raise_on_error=False):
     """Checks that the merges in an action tsv are possible.
 
-    To be mergable the
+    To be mergeable the
     """
     actions = pd.read_table(action_tsv)
     ok_merges = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
 requires = ["setuptools >= 40.8.0", "wheel"]
+
+[tool.codespell]
+skip = '*.svg,_version.py,*.pem,*.json,testdata'
+#
+# ignore-words-list = ''
+

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,6 @@ envlist = codespell
 skip_install = true
 deps =
     codespell~=2.0
+    tomli
 commands =
-    codespell -D- --skip "_version.py,*.pem,*.json" {posargs} cubds docs notebooks tests
+    codespell {posargs}


### PR DESCRIPTION
I have made a typo in `cubds` so in effect `codespell` was not in effect. 