### PR TITLE
Remove `--ignore_subject_consistency` param from `cubids validate`

### DIFF
--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -62,16 +62,6 @@ def _parse_validate():
         required=False,
     )
     parser.add_argument(
-        "--ignore_subject_consistency",
-        action="store_true",
-        default=True,
-        help=(
-            "Skip checking that any given file for one "
-            "subject is present for all other subjects"
-        ),
-        required=False,
-    )
-    parser.add_argument(
         "--sequential-subjects",
         action="store",
         default=None,

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -150,7 +150,7 @@ class CuBIDS(object):
         Uses git reset --hard to revert to the previous commit.
         """
         if not self.is_datalad_clean():
-            raise Exception("Untracked changes present. " "Run clear_untracked_changes first")
+            raise Exception("Untracked changes present. Run clear_untracked_changes first")
         reset_proc = subprocess.run(["git", "reset", "--hard", "HEAD~1"], cwd=self.path)
         reset_proc.check_returncode()
 

--- a/cubids/validator.py
+++ b/cubids/validator.py
@@ -14,13 +14,11 @@ logger = logging.getLogger("cubids-cli")
 def build_validator_call(path, ignore_headers=False):
     """Build a subprocess command to the bids validator."""
     # build docker call
-    command = ["bids-validator", "--verbose", "--json"]
+    # CuBIDS automatically ignores subject consistency.
+    command = ["bids-validator", "--verbose", "--json", "--ignoreSubjectConsistency"]
 
     if ignore_headers:
         command.append("--ignoreNiftiHeaders")
-
-    # CuBIDS automatically ignores subject consistency.
-    command.append("--ignoreSubjectConsistency")
 
     command.append(path)
 

--- a/cubids/validator.py
+++ b/cubids/validator.py
@@ -38,7 +38,7 @@ def build_subject_paths(bids_dir):
     subjects = glob.glob(bids_dir)
 
     if len(subjects) < 1:
-        raise ValueError("Couldn't find any subjects " "in the specified directory:\n" + bids_dir)
+        raise ValueError("Couldn't find any subjects in the specified directory:\n" + bids_dir)
 
     subjects_dict = {}
 
@@ -93,7 +93,7 @@ def parse_validator_output(output):
         return_dict["files"] = [
             get_nested(x, "file", "relativePath") for x in issue_dict.get("files", "")
         ]
-        return_dict["type"] = issue_dict.get("key" "")
+        return_dict["type"] = issue_dict.get("key", "")
         return_dict["severity"] = issue_dict.get("severity", "")
         return_dict["description"] = issue_dict.get("reason", "")
         return_dict["code"] = issue_dict.get("code", "")

--- a/cubids/validator.py
+++ b/cubids/validator.py
@@ -11,15 +11,16 @@ import pandas as pd
 logger = logging.getLogger("cubids-cli")
 
 
-def build_validator_call(path, ignore_headers=False, ignore_subject=True):
+def build_validator_call(path, ignore_headers=False):
     """Build a subprocess command to the bids validator."""
     # build docker call
     command = ["bids-validator", "--verbose", "--json"]
 
     if ignore_headers:
         command.append("--ignoreNiftiHeaders")
-    if ignore_subject:
-        command.append("--ignoreSubjectConsistency")
+
+    # CuBIDS automatically ignores subject consistency.
+    command.append("--ignoreSubjectConsistency")
 
     command.append(path)
 

--- a/cubids/workflows.py
+++ b/cubids/workflows.py
@@ -37,7 +37,6 @@ def validate(
     sequential,
     sequential_subjects,
     ignore_nifti_headers,
-    ignore_subject_consistency,
 ):
     """Run the bids validator.
 
@@ -49,7 +48,6 @@ def validate(
     sequential
     sequential_subjects
     ignore_nifti_headers
-    ignore_subject_consistency
     """
     # check status of output_prefix, absolute or relative?
     abs_path_output = True
@@ -69,7 +67,6 @@ def validate(
             call = build_validator_call(
                 str(bids_dir),
                 ignore_nifti_headers,
-                ignore_subject_consistency,
             )
             ret = run_validator(call)
 
@@ -148,8 +145,7 @@ def validate(
 
                     # run the validator
                     nifti_head = ignore_nifti_headers
-                    subj_consist = ignore_subject_consistency
-                    call = build_validator_call(tmpdirname, nifti_head, subj_consist)
+                    call = build_validator_call(tmpdirname, nifti_head)
                     ret = run_validator(call)
                     # parse output
                     if ret.returncode != 0:
@@ -228,9 +224,6 @@ def validate(
         if ignore_nifti_headers:
             cmd.append("--ignore_nifti_headers")
 
-        if ignore_subject_consistency:
-            cmd.append("--ignore_subject_consistency")
-
     elif container_type == "singularity":
         cmd = [
             "singularity",
@@ -249,9 +242,6 @@ def validate(
         ]
         if ignore_nifti_headers:
             cmd.append("--ignore_nifti_headers")
-
-        if ignore_subject_consistency:
-            cmd.append("--ignore_subject_consistency")
 
         if sequential:
             cmd.append("--sequential")


### PR DESCRIPTION
Closes #270.

Changes proposed:

- Drop the `--ignore_subject_consistency` parameter, which could only be set to True.
- Automatically add `--ignoreSubjectConsistency` to the BIDS validator call used by `cubids validate`.