### PR TITLE
Attempt to fix PyPi deployment again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,15 +74,14 @@ jobs:
       - checkout:
           path: /home/circleci/src/CuBIDS
       - run:
-          name: Generate distribution archives
-          command: |
-            python3 -m pip install --upgrade build
-            python3 -m build
+          name: Update build tools
+          command: pip install --upgrade build twine
       - run:
-          name: Upload packages to PyPI
-          command: |
-            python3 -m pip install --upgrade twine
-            python3 -m twine upload dist/*
+          name: Build CuBIDS
+          command: python -m build
+      - run:
+          name: Upload package to PyPI
+          command: python -m twine upload -u __token__ -p ${PYPI_TOKEN} dist/cubids*
 
 workflows:
   version: 2


### PR DESCRIPTION
Closes #280. Feed in the password and username when uploading.