### PR TITLE
logger not printing metadata so use print instead

### DIFF
--- a/cubids/workflows.py
+++ b/cubids/workflows.py
@@ -895,7 +895,7 @@ def print_metadata_fields(bids_dir, container):
     if container is None:
         bod = CuBIDS(data_root=str(bids_dir), use_datalad=False)
         fields = bod.get_all_metadata_fields()
-        print("\n".join(fields)) # logger not printing
+        print("\n".join(fields))  # logger not printing
         # logger.info("\n".join(fields))
         sys.exit(0)
 

--- a/cubids/workflows.py
+++ b/cubids/workflows.py
@@ -895,7 +895,8 @@ def print_metadata_fields(bids_dir, container):
     if container is None:
         bod = CuBIDS(data_root=str(bids_dir), use_datalad=False)
         fields = bod.get_all_metadata_fields()
-        logger.info("\n".join(fields))
+        print("\n".join(fields)) # logger not printing
+        # logger.info("\n".join(fields))
         sys.exit(0)
 
     # Run it through a container


### PR DESCRIPTION
Closes #332.

## Changes proposed in this pull request

`cubids print-metadata-fields bids_dir` used logger that didn't print metadata to terminal. Replaced with `print()` instead.

## Documentation that should be reviewed

None
