### PR TITLE
Use relative path in `git mv` for `cubids apply` with `--use-datalad`

### DIFF
--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -410,7 +410,7 @@ class CuBIDS(object):
                 if Path(from_file).exists():
                     # if using datalad, we want to git mv instead of mv
                     if self.use_datalad:
-                        move_ops.append(f"git mv {from_file} {to_file}")
+                        move_ops.append(f"git mv {os.path.relpath(from_file,str(self.path))} {to_file}")
                     else:
                         move_ops.append(f"mv {from_file} {to_file}")
 


### PR DESCRIPTION
Closes none, but allows `cubids apply` to run with datalad.