### PR TITLE
Use force_unlock in copy_exemplars Python workflow

### DIFF
--- a/cubids/workflows.py
+++ b/cubids/workflows.py
@@ -691,7 +691,7 @@ def copy_exemplars(
     """
     # Run directly from python using
     if container is None:
-        bod = CuBIDS(data_root=str(bids_dir), use_datalad=use_datalad)
+        bod = CuBIDS(data_root=str(bids_dir), use_datalad=use_datalad, force_unlock=force_unlock)
         if use_datalad:
             if not bod.is_datalad_clean():
                 raise Exception(


### PR DESCRIPTION
Closes none, but addresses a bug I noticed in #394. It looks like `copy_exemplars()` uses the `force_unlock` argument when running in a container, but _not_ when running just with Python.

## Changes proposed in this pull request

- Use `force_unlock` when initializing CuBIDS object in `copy_exemplars` workflow function.
