### PR TITLE
Avoid copying shell prompt $ when copying example commands from docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ data/*
 notebooks/testdata
 .vscode/settings.json
 notebooks/test1
+docs/generated

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,5 +264,5 @@ hoverxref_roles = [
 # sphinx_copybutton
 # -----------------------------------------------------------------------------
 # Configuration for sphinx_copybutton to remove shell prompts, i.e. $
-copybutton_prompt_text = r'^\$ '  # matching lines starting with "$ "
+copybutton_prompt_text = r'^(\.\.\s+|(\s+)?\$) ' # matching lines starting with "$ "
 copybutton_only_copy_prompt_lines = False  # ensures all lines are copied, even those without a prompt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,5 +264,5 @@ hoverxref_roles = [
 # sphinx_copybutton
 # -----------------------------------------------------------------------------
 # Configuration for sphinx_copybutton to remove shell prompts, i.e. $
-copybutton_prompt_text = r'^(\.\.\s+|(\s+)?\$) ' # matching lines starting with "$ "
+copybutton_prompt_text = "$ "
 copybutton_only_copy_prompt_lines = False  # ensures all lines are copied, even those without a prompt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -259,3 +259,10 @@ hoverxref_roles = [
     "term",
     "footcite",
 ]
+
+# -----------------------------------------------------------------------------
+# sphinx_copybutton
+# -----------------------------------------------------------------------------
+# Configuration for sphinx_copybutton to remove shell prompts, i.e. $
+copybutton_prompt_text = r'^\$ '  # matching lines starting with "$ "
+copybutton_only_copy_prompt_lines = False  # ensures all lines are copied, even those without a prompt


### PR DESCRIPTION
Closes #395

## Changes proposed in this pull request

- Now when user tries to copy example commands from the docs, they won't be pasting the shell prompt symbol ($) too
- added configuration for sphinx_copybutton in conf.py