### PR TITLE
Fixing bug to allow filenames in cubids apply and cubids copy-exemplars

### DIFF
--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -554,7 +554,7 @@ def _parse_apply():
     )
     parser.add_argument(
         "edited_summary_tsv",
-        type=IsFile,
+        type=Path,
         action="store",
         help=(
             "path to the _summary.tsv that has been edited "
@@ -566,7 +566,7 @@ def _parse_apply():
     )
     parser.add_argument(
         "files_tsv",
-        type=IsFile,
+        type=Path,
         action="store",
         help=(
             "path to the _files.tsv that has been edited "
@@ -876,7 +876,7 @@ def _parse_copy_exemplars():
     )
     parser.add_argument(
         "exemplars_dir",
-        type=PathExists,
+        type=Path,
         action="store",
         help=(
             "name of the directory to create where to store exemplar dataset. "
@@ -887,7 +887,7 @@ def _parse_copy_exemplars():
     )
     parser.add_argument(
         "exemplars_tsv",
-        type=IsFile,
+        type=Path,
         action="store",
         help=(
             "path to the .tsv that lists one "

--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -862,7 +862,7 @@ def _parse_copy_exemplars():
         allow_abbrev=False,
     )
     PathExists = partial(_path_exists, parser=parser)
-    IsFile = partial(_is_file, parser=parser)
+    #IsFile = partial(_is_file, parser=parser)
 
     parser.add_argument(
         "bids_dir",

--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -862,7 +862,7 @@ def _parse_copy_exemplars():
         allow_abbrev=False,
     )
     PathExists = partial(_path_exists, parser=parser)
-    #IsFile = partial(_is_file, parser=parser)
+    # IsFile = partial(_is_file, parser=parser)
 
     parser.add_argument(
         "bids_dir",


### PR DESCRIPTION
Closes #340 

## Changes proposed in this pull request

- Changed type of parsing to allow locating files that are not located in the current working directory
- see also https://github.com/PennLINC/CuBIDS/issues/340#issuecomment-2598658970 for more details

## Documentation that should be reviewed

- none