### PR TITLE
cubids print-metadata-fields exits if no dataset_desciption.json

### DIFF
--- a/cubids/workflows.py
+++ b/cubids/workflows.py
@@ -952,15 +952,36 @@ def remove_metadata_fields(bids_dir, container, fields):
 
 
 def print_metadata_fields(bids_dir, container):
-    """Print unique metadata fields.
+    """Print unique metadata fields from a BIDS dataset.
+
+    This function identifies and prints all unique metadata fields from
+    the `dataset_description.json` file in a BIDS directory. It can run
+    either directly in Python or within a specified container (Docker or
+    Singularity).
 
     Parameters
     ----------
     bids_dir : :obj:`pathlib.Path`
-        Path to the BIDS directory.
+        Path to the BIDS directory containing the `dataset_description.json` file.
     container : :obj:`str`
-        Container in which to run the workflow.
+        Name of the container (e.g., Docker, Singularity) to use for running the
+        `cubids print-metadata-fields` command. If `None`, the operation is performed
+        directly in Python without a container.
+
+    Raises
+    ------
+    SystemExit
+        Raised in the following cases:
+        - The `dataset_description.json` file is not found in the BIDS directory.
+        - The subprocess returns a non-zero exit code when executed in a container.
+
     """
+    # Check if dataset_description.json exists
+    dataset_description = bids_dir / "dataset_description.json"
+    if not dataset_description.exists():
+        logger.error("dataset_description.json not found in the BIDS directory.")
+        sys.exit(1)
+
     # Run directly from python
     if container is None:
         bod = CuBIDS(data_root=str(bids_dir), use_datalad=False)


### PR DESCRIPTION
Closes #198.

## Changes proposed in this pull request

- `cubids print-metadata-fields` checks for `dataset_description.json` in `bids_dir` and exits if not found. This address a bug where it would run for a long time if passed a non-existent dataset.
