### PR TITLE
Variant renaming suggestions are ignoring tolerances

### DIFF
--- a/cubids/config.py
+++ b/cubids/config.py
@@ -19,7 +19,7 @@ def load_config(config_file):
     dict
         The configuration loaded from the YAML file.
     """
-    if config_file is None:
+    if not config_file:
         config_file = Path(importlib.resources.files("cubids") / "data/config.yml")
 
     with config_file.open() as f:

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1020,7 +1020,7 @@ class CuBIDS(object):
                 modality = mod.replace("/", "").replace("/", "")
 
         if modality == "":
-            print("Unusual Modality Detected")
+            print(f"Unusual Modality Detected: {filepath}")
             modality = "other"
 
         ret = _get_param_groups(

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1911,14 +1911,6 @@ def _get_param_groups(
     # sort ordered_labeled_files by param group
     ordered_labeled_files.sort_values(by=["Counts"], inplace=True, ascending=False)
 
-    # now get rid of cluster cols from deduped and df
-    for col in list(ordered_labeled_files.columns):
-        if col.startswith("Cluster_"):
-            ordered_labeled_files = ordered_labeled_files.drop(col, axis=1)
-            param_groups_with_counts = param_groups_with_counts.drop(col, axis=1)
-        if col.endswith("_x"):
-            ordered_labeled_files = ordered_labeled_files.drop(col, axis=1)
-
     return ordered_labeled_files, param_groups_with_counts
 
 

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1289,6 +1289,10 @@ class CuBIDS(object):
                 for col in rename_cols:
                     summary[col] = summary[col].apply(str)
                     val[col] = summary.loc[row, col]
+
+                    if f"Cluster_{col}" in summary.columns:
+                        val[f"Cluster_{col}"] = summary.loc[row, f"Cluster_{col}"]
+
                 dom_dict[key] = val
 
         # now loop through again and ID variance
@@ -1308,17 +1312,22 @@ class CuBIDS(object):
                 acq_str = "VARIANT"
                 # now we know we have a deviant param group
                 # check if TR is same as param group 1
-                key = summary.loc[row, "EntitySet"]
+                entity_set = summary.loc[row, "EntitySet"]
                 for col in rename_cols:
+                    dom_entity_set = dom_dict[entity_set]
                     summary[col] = summary[col].apply(str)
-                    if summary.loc[row, col] != dom_dict[key][col]:
+
+                    if f"Cluster_{col}" in dom_entity_set.keys():
+                        if summary.loc[row, f"Cluster_{col}"] != dom_entity_set[f"Cluster_{col}"]:
+                            acq_str += col
+                    elif summary.loc[row, col] != dom_entity_set[col]:
                         if col == "HasFieldmap":
-                            if dom_dict[key][col] == "True":
+                            if dom_entity_set[col] == "True":
                                 acq_str = acq_str + "NoFmap"
                             else:
                                 acq_str = acq_str + "HasFmap"
                         elif col == "UsedAsFieldmap":
-                            if dom_dict[key][col] == "True":
+                            if dom_entity_set[col] == "True":
                                 acq_str = acq_str + "Unused"
                             else:
                                 acq_str = acq_str + "IsUsed"

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1330,14 +1330,16 @@ class CuBIDS(object):
         group_by_acquisition_sets(files_tsv, path_prefix, self.acq_group_level)
 
         print(f"CuBIDS detected {len(summary)} Parameter Groups.")
-        print(f"""Groupings info is available in
+        print(
+            f"""Groupings info is available in
 
   * {files_tsv}
   * {files_json}
   * {summary_tsv}
   * {summary_json}
 
-""")
+"""
+        )
 
     def get_entity_sets(self):
         """Identify the entity sets for the BIDS dataset.

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1385,20 +1385,33 @@ class CuBIDS(object):
         summary_dict = self.get_data_dictionary(summary)
 
         # Save data dictionaires as JSONs
-        with open(f"{path_prefix}_files.json", "w") as outfile:
+        files_tsv = f"{path_prefix}_files.tsv"
+        files_json = f"{path_prefix}_files.json"
+        summary_tsv = f"{path_prefix}_summary.tsv"
+        summary_json = f"{path_prefix}_summary.json"
+
+        with open(files_json, "w") as outfile:
             json.dump(files_dict, outfile, indent=4)
 
-        with open(f"{path_prefix}_summary.json", "w") as outfile:
+        with open(summary_json, "w") as outfile:
             json.dump(summary_dict, outfile, indent=4)
 
-        big_df.to_csv(f"{path_prefix}_files.tsv", sep="\t", index=False)
+        big_df.to_csv(files_tsv, sep="\t", index=False)
 
-        summary.to_csv(f"{path_prefix}_summary.tsv", sep="\t", index=False)
+        summary.to_csv(summary_tsv, sep="\t", index=False)
 
         # Calculate the acq groups
-        group_by_acquisition_sets(f"{path_prefix}_files.tsv", path_prefix, self.acq_group_level)
+        group_by_acquisition_sets(files_tsv, path_prefix, self.acq_group_level)
 
         print(f"CuBIDS detected {len(summary)} Parameter Groups.")
+        print(f"""Groupings info is available in
+
+  * {files_tsv}
+  * {files_json}
+  * {summary_tsv}
+  * {summary_json}
+
+""")
 
     def get_entity_sets(self):
         """Identify the entity sets for the BIDS dataset.

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1709,7 +1709,7 @@ def _get_param_groups(
 
     Returns
     -------
-    labeled_files : :obj:`pandas.DataFrame`
+    ordered_labeled_files : :obj:`pandas.DataFrame`
         A data frame with one row per file where the ParamGroup column
         indicates which group each scan is a part of.
     param_groups_with_counts : :obj:`pandas.DataFrame`


### PR DESCRIPTION
@B-Sevchik was running into an issue where she was editing the tolerance and precision of dmri VoxelSizeDim3 and no matter how large she set the tolerance to, the suggested rename would include VoxelSizeDim3.

I went through the grouping functions and found that the parameter grouping _is_ working correctly, but the variant renaming is ignoring the tolerances. What happens is

 1. Parameter grouping correctly detects a difference in any parameter. In Brooke's case it is `Obliquity` and marks some scans as variants. 
 2. When it comes time to suggest a variant rename, all of the parameters get checked to see if they differ from the dominant group. Here, a strict equals comparison is used instead of the tolerance parameter  [specifically, here](https://github.com/PennLINC/CuBIDS/blob/49d9e88f145c786d1f2fb918e213c0f5f1cab5c4/cubids/cubids.py#L1314).

I think the fix for this is to grab the config for the modality in question, find whether this parameter has a tolerance specified, and if it does that means this parameter is numeric and should be compared with the tolerance in mind.