### PR TITLE
add_nifti_info ImageOrientation 'None' in tuple fix

### DIFF
--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -379,6 +379,7 @@ class CuBIDS(object):
                             data["NumVolumes"] = 1
                     if "ImageOrientation" not in data.keys():
                         orient = nb.orientations.aff2axcodes(img.affine)
+                        orient = [str(orientation) for orientation in orient]
                         joined = "".join(orient) + "+"
                         data["ImageOrientation"] = joined
 


### PR DESCRIPTION

## Changes proposed in this pull request

- Add line which casts all orientations in tuple to be a string before they are joined together. This catches the None in the tuple before it is joined as a string.
<img width="591" alt="cubids_add_nifti_info_error" src="https://github.com/user-attachments/assets/4e83cee0-5ab3-4818-b0b0-e39ad9e2ac35" />


## Documentation that should be reviewed

- add_nifti_info function contains the fix and should be reviewed
