### PR TITLE
Clarify handling of non-BIDS entities in entity sets (e.g., `fmap-epi`)

### DIFF
--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -129,6 +129,13 @@ def _file_to_entity_set(filename):
     str
         A set of entities extracted from the filename.
 
+    Notes
+    -----
+    This function relies on the variable NON_KEY_ENTITIES from cubids.constants.
+    This is a set of entities to ignore in the entity set.
+    The constant may be modified by the CuBIDS class, which will remove "session"
+    if is_longitudinal is True and acq_group_level is "session".
+
     Examples
     --------
     >>> _file_to_entity_set("sub-01_ses-01_task-rest_bold.nii.gz")

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -104,11 +104,15 @@ def _entities_to_entity_set(entities):
     str
         A string representing the entity set name, constructed by joining
         the sorted entity keys and their corresponding values, separated by hyphens.
+
+    Notes
+    -----
+    This function relies on the variable NON_KEY_ENTITIES from cubids.constants.
+    This is a set of entities to ignore in the entity set.
+    The constant may be modified by the CuBIDS class, which will remove "session"
+    if is_longitudinal is True and acq_group_level is "session".
     """
     group_keys = sorted(set(entities.keys()) - NON_KEY_ENTITIES)
-    if "session" in group_keys:
-        raise Exception(NON_KEY_ENTITIES)
-
     return "_".join([f"{key}-{entities[key]}" for key in group_keys])
 
 
@@ -128,11 +132,11 @@ def _file_to_entity_set(filename):
     Examples
     --------
     >>> _file_to_entity_set("sub-01_ses-01_task-rest_bold.nii.gz")
-    'suffix-bold_task-rest'
+    'session-01_suffix-bold_task-rest'
 
     Field maps will have an extraneous "fmap" entity.
     >>> _file_to_entity_set("sub-01_ses-01_dir-AP_epi.nii.gz")
-    'direction-AP_fmap-epi_suffix-epi'
+    'direction-AP_fmap-epi_session-01_suffix-epi'
     """
     entities = parse_file_entities(str(filename))
     return _entities_to_entity_set(entities)

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -107,7 +107,7 @@ def _entities_to_entity_set(entities):
     """
     group_keys = sorted(set(entities.keys()) - NON_KEY_ENTITIES)
     if "session" in group_keys:
-        raise Exception()
+        raise Exception(NON_KEY_ENTITIES)
 
     return "_".join([f"{key}-{entities[key]}" for key in group_keys])
 

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -105,7 +105,7 @@ def _entities_to_entity_set(entities):
         A string representing the entity set name, constructed by joining
         the sorted entity keys and their corresponding values, separated by hyphens.
     """
-    group_keys = sorted(entities.keys() - NON_KEY_ENTITIES)
+    group_keys = sorted(set(entities.keys()) - NON_KEY_ENTITIES)
     return "_".join([f"{key}-{entities[key]}" for key in group_keys])
 
 

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -106,6 +106,9 @@ def _entities_to_entity_set(entities):
         the sorted entity keys and their corresponding values, separated by hyphens.
     """
     group_keys = sorted(set(entities.keys()) - NON_KEY_ENTITIES)
+    if "session" in group_keys:
+        raise Exception()
+
     return "_".join([f"{key}-{entities[key]}" for key in group_keys])
 
 

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -84,8 +84,8 @@ def _entity_set_to_entities(entity_set):
 
     Examples
     --------
-    >>> _entity_set_to_entities("sub-01_ses-02_task-rest")
-    {'sub': '01', 'ses': '02', 'task': 'rest'}
+    >>> _entity_set_to_entities("subject-01_session-02_task-rest")
+    {'subject': '01', 'session': '02', 'task': 'rest'}
     """
     return dict([group.split("-") for group in entity_set.split("_")])
 
@@ -125,7 +125,11 @@ def _file_to_entity_set(filename):
     Examples
     --------
     >>> _file_to_entity_set("sub-01_ses-01_task-rest_bold.nii.gz")
-    'session-01_suffix-bold_task-rest'
+    'suffix-bold_task-rest'
+
+    Field maps will have an extraneous "fmap" entity.
+    >>> _file_to_entity_set("sub-01_ses-01_dir-AP_epi.nii.gz")
+    'direction-AP_fmap-epi_suffix-epi'
     """
     entities = parse_file_entities(str(filename))
     return _entities_to_entity_set(entities)
@@ -716,7 +720,7 @@ def build_path(filepath, out_entities, out_dir, schema, is_longitudinal):
     ... )
     '/output/sub-01/ses-01/func/sub-01_ses-01_task-rest_acq-VAR_bold.nii.gz'
 
-    But uncommon (but BIDS-valid) entities, like echo, will work.
+    Uncommon (but BIDS-valid) entities, like echo, will work.
 
     >>> build_path(
     ...    "/input/sub-01/ses-01/func/sub-01_ses-01_task-rest_run-01_bold.nii.gz",
@@ -726,6 +730,17 @@ def build_path(filepath, out_entities, out_dir, schema, is_longitudinal):
     ...    True,
     ... )
     '/output/sub-01/ses-01/func/sub-01_ses-01_task-rest_acq-VAR_echo-1_bold.nii.gz'
+
+    But non-BIDS entities, like fmap, will be ignored.
+
+    >>> build_path(
+    ...    "/input/sub-01/ses-01/fmap/sub-01_ses-01_dir-AP_epi.nii.gz",
+    ...    {"acquisition": "VAR", "direction": "AP", "fmap": "epi", "suffix": "epi"},
+    ...    "/output",
+    ...    schema,
+    ...    True,
+    ... )
+    '/output/sub-01/ses-01/fmap/sub-01_ses-01_acq-VAR_dir-AP_epi.nii.gz'
 
     It can change the datatype, but will warn the user.
 

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -331,7 +331,7 @@ based on acquisition fields such as dimension and voxel sizes, number of volumes
 
 While ``v0_validation.tsv`` identified all the BIDS validation errors present in the dataset,
 it did not identify any potential issues that might be present within the sidecars' metadata.
-Below, we see insances of missing metadata fields in a handful of sidecars,
+Below, we see instances of missing metadata fields in a handful of sidecars,
 which may impact successful execution of BIDS Apps.
 
 .. csv-table:: v0_summary.tsv

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -185,8 +185,8 @@ BIDS validation
     but can be slowed down by extremely large datasets.
 
 .. warning::
-    For internetless use cases, please see dedicated section of the `Installation page 
-    <https://cubids.readthedocs.io/en/latest/installation.html>`_ on how to download a local version 
+    For internetless use cases, please see dedicated section of the `Installation page
+    <https://cubids.readthedocs.io/en/latest/installation.html>`_ on how to download a local version
     of the validator.
 
     After that, you will need to add ``--local-validator`` option to the command string above.
@@ -216,7 +216,7 @@ To do this, we run the ``cubids purge`` command.
 ``cubids purge`` requires as input a list of files to cleanly "purge" from the dataset.
 You can create this file in any text editor,
 as long as it is saved as plain text ``.txt``.
-When specifying files in this text file, 
+When specifying files in this text file,
 always use relative paths starting from your BIDS directory.
 For this example, we created the following file:
 
@@ -314,10 +314,20 @@ This command will produce four tables that describe the dataset's heterogeneity 
 #.  ``v0_AcqGrouping.tsv`` maps each session in the dataset to an Acquisition Group.
 #.  ``v0_AcqGroupInfo.txt`` lists the set of scanning parameters present in each Acquisition Group.
 
-By first examining ``v0_summary.tsv`` users are given he opportunity to conduct metadata
+By first examining ``v0_summary.tsv`` users are given the opportunity to conduct metadata
 quality assurance (QA).
 The file can help identify instances of incomplete, incorrect, or unusable parameter groups,
 based on acquisition fields such as dimension and voxel sizes, number of volumes, obliquity, and more.
+
+.. warning::
+
+    You may see some non-BIDS entities in the entity sets;
+    for example, ``fmap-<suffix>`` is generally present for fieldmaps,
+    even though ``fmap`` is not a BIDS entity.
+    This is because ``PyBIDS`` includes some custom entities that are not part of the BIDS specification.
+
+    Don't worry about these.
+    The step that generates filenames from the entity sets should ignore them automatically.
 
 While ``v0_validation.tsv`` identified all the BIDS validation errors present in the dataset,
 it did not identify any potential issues that might be present within the sidecars' metadata.


### PR DESCRIPTION
Closes none, but is related to #425 (same set of issues @B-Sevchik is working on).

## Changes proposed in this pull request

- Account for `fmap-epi` in field map entities (this is introduced by pybids's `parse_file_entities` function, which uses a Config that includes "fmap" as an entity).

## Documentation that should be reviewed

-
