### PR TITLE
Add "C" prefix to cluster values in variants

### DIFF
--- a/cubids/tests/test_variants.py
+++ b/cubids/tests/test_variants.py
@@ -30,11 +30,13 @@ def base_df():
     pandas.DataFrame
         A DataFrame with basic structure needed for assign_variants testing
     """
-    return pd.DataFrame({
-        "ParamGroup": ["1", "2", "2"],
-        "EntitySet": ["task-test", "task-test", "task-test"],
-        "RenameEntitySet": ["", "", ""]
-    })
+    return pd.DataFrame(
+        {
+            "ParamGroup": ["1", "2", "2"],
+            "EntitySet": ["task-test", "task-test", "task-test"],
+            "RenameEntitySet": ["", "", ""],
+        }
+    )
 
 
 def test_assign_variants_with_cluster_values(base_df):
@@ -47,8 +49,8 @@ def test_assign_variants_with_cluster_values(base_df):
     result = assign_variants(base_df, ["EchoTime"])
 
     # Check that variant names include cluster values
-    assert "acquisition-VARIANTEchoTime2_" in result.loc[1, "RenameEntitySet"]
-    assert "acquisition-VARIANTEchoTime3_" in result.loc[2, "RenameEntitySet"]
+    assert "acquisition-VARIANTEchoTimeC2_" in result.loc[1, "RenameEntitySet"]
+    assert "acquisition-VARIANTEchoTimeC3_" in result.loc[2, "RenameEntitySet"]
 
 
 def test_assign_variants_mixed_parameters(base_df):
@@ -62,8 +64,8 @@ def test_assign_variants_mixed_parameters(base_df):
     result = assign_variants(base_df, ["EchoTime", "FlipAngle"])
 
     # Check variant names include both cluster values and actual values
-    assert "acquisition-VARIANTEchoTime2FlipAngle75_" in result.loc[1, "RenameEntitySet"]
-    assert "acquisition-VARIANTEchoTime3FlipAngle60_" in result.loc[2, "RenameEntitySet"]
+    assert "acquisition-VARIANTEchoTimeC2FlipAngle75_" in result.loc[1, "RenameEntitySet"]
+    assert "acquisition-VARIANTEchoTimeC3FlipAngleC60_" in result.loc[2, "RenameEntitySet"]
 
 
 def test_assign_variants_special_parameters(base_df):

--- a/cubids/tests/test_variants.py
+++ b/cubids/tests/test_variants.py
@@ -65,7 +65,7 @@ def test_assign_variants_mixed_parameters(base_df):
 
     # Check variant names include both cluster values and actual values
     assert "acquisition-VARIANTEchoTimeC2FlipAngle75_" in result.loc[1, "RenameEntitySet"]
-    assert "acquisition-VARIANTEchoTimeC3FlipAngleC60_" in result.loc[2, "RenameEntitySet"]
+    assert "acquisition-VARIANTEchoTimeC3FlipAngle60_" in result.loc[2, "RenameEntitySet"]
 
 
 def test_assign_variants_special_parameters(base_df):

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -931,7 +931,7 @@ def assign_variants(summary, rename_cols):
                 if f"Cluster_{col}" in dom_entity_set.keys():
                     if summary.loc[row, f"Cluster_{col}"] != dom_entity_set[f"Cluster_{col}"]:
                         cluster_val = summary.loc[row, f"Cluster_{col}"]
-                        acq_str += f"{col}{int(cluster_val)}"
+                        acq_str += f"{col}C{int(cluster_val)}"
                 elif summary.loc[row, col] != dom_entity_set[col]:
                     if col == "HasFieldmap":
                         if dom_entity_set[col] == "True":


### PR DESCRIPTION
Closes #437.

## Changes proposed in this pull request

- Add "C" prefix to cluster values in variants. So the auto-generated variant might go from `acq-VARIANTEchoTime1FlipAngle75` to `acq-VARIANTEchoTimeC1FlipAngle75`
