### PR TITLE
Strip p0 from all values

### DIFF
--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -1001,9 +1001,10 @@ def assign_variants(summary, rename_cols):
                         # If the value is an actual float
                         elif isinstance(val, float):
                             val = str(val).replace(".", "p")
-                            if val.endswith("p0"):
-                                # Remove the trailing "p0"
-                                val = val[:-2]
+
+                        if val.endswith("p0"):
+                            # Remove the trailing "p0"
+                            val = val[:-2]
 
                         # Filter out non-alphanumeric characters
                         val = re.sub(r"[^a-zA-Z0-9]", "", val)


### PR DESCRIPTION
Closes none, but stems from https://github.com/PennLINC/CuBIDS/pull/443#discussion_r1975369269.

## Changes proposed in this pull request

- Remove trailing `p0` from non-float values as well as float values.
