### PR TITLE
Add `cubids date-time-shift`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ workflows:
           matrix:
             parameters:
               python_version:
-                - "3.10"
                 - "3.11"
                 - "3.12"
                 - "3.13"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  codecov: codecov/codecov@5.2.1
 
 jobs:
   run_pytests:
@@ -66,11 +64,7 @@ jobs:
           command: |
             conda create -n cov python=3.12 pip coverage
             source activate cov
-
-            # We need curl for the codecov upload
-            apt-get update
-            apt-get install -y -qq curl
-            apt-get install -y gnupg
+            pip install --disable-pip-version-check codecov-cli==11.3.1
 
             # Generate XML from the checked-out repository path so Codecov can
             # resolve file paths against the commit contents.
@@ -91,17 +85,17 @@ jobs:
           name: Validate Codecov token format
           command: |
             python -c "import os; t=os.getenv('CODECOV_TOKEN',''); print(f'CODECOV_TOKEN length: {len(t)}'); print(f'CODECOV_TOKEN has_whitespace: {any(ch.isspace() for ch in t)}')"
-      # Set CODECOV_TOKEN in CircleCI project settings using the repository upload token from:
-      # https://app.codecov.io/gh/PennLINC/CuBIDS/settings
-      - codecov/upload:
-          files: /home/circleci/src/CuBIDS/coverage.xml
-          dir: /home/circleci/src/CuBIDS
-          git_service: github
-          slug: PennLINC/CuBIDS
-          token: CODECOV_TOKEN
-          disable_search: true
-          fail_on_error: false
-          verbose: true
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            source activate cov
+            # CODECOV_TOKEN is the repository upload token stored in CircleCI project settings.
+            codecovcli --verbose upload-process \
+              --disable-search \
+              --git-service github \
+              --slug PennLINC/CuBIDS \
+              --token "$CODECOV_TOKEN" \
+              --file /home/circleci/src/CuBIDS/coverage.xml
 
   deployable:
     docker:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         pip install flake8 flake8-absolute-import flake8-black flake8-docstrings \

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,7 +103,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2.  If the pull request adds functionality, the docs should be updated. Put
     your new functionality into a function with a docstring, and add the
     feature to the list in README.rst.
-3.  The pull request should work for Python 3.9, 3.10, 3.11, 3.12 and 3.13, and for PyPI.
+3.  The pull request should work for Python 3.11, 3.12 and 3.13, and for PyPI.
     Check https://circleci.com/gh/PennLINC/CuBIDS
     and make sure that the tests pass for all supported Python versions.
 

--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -80,6 +80,16 @@ def _is_file(path, parser):
     return path
 
 
+def _is_dir(path, parser):
+    """Ensure a given path exists and is a directory."""
+    path = _path_exists(path, parser)
+    if not path.is_dir():
+        raise parser.error(
+            f"Path should point to a directory (or symlink of directory): <{path.absolute()}>."
+        )
+    return path
+
+
 def _parse_validate():
     """Create and configure the argument parser for the `cubids validate` command.
 
@@ -1101,6 +1111,70 @@ def _parse_print_metadata_fields():
     return parser
 
 
+def _parse_date_time_shift():
+    """Create the parser for the ``cubids date-time-shift`` command.
+
+    This function configures the command that de-identifies BIDS acquisition
+    dates and rounds acquisition times. It shifts each subject's earliest
+    rounded date in subject- and session-level ``*_scans.tsv`` files to
+    ``1800-01-01`` while preserving calendar-day intervals, and rounds
+    acquisition times in scans tables and JSON sidecars to the nearest hour.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The configured argument parser for the ``cubids date-time-shift``
+        command.
+
+    Notes
+    -----
+    The parser accepts the following arguments:
+
+    - bids_dir: Root of the BIDS dataset to update in place.
+    - --dry-run: Report planned changes without writing files.
+    - --n-cpus: Number of workers used to read and plan independent updates.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "cubids date-time-shift: de-identify scans.tsv acquisition dates and round "
+            "acquisition times"
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        allow_abbrev=False,
+    )
+    IsDir = partial(_is_dir, parser=parser)
+
+    parser.add_argument(
+        "bids_dir",
+        type=IsDir,
+        action="store",
+        help=(
+            "The root of the BIDS dataset to update in place. Run this before checking "
+            "the dataset into DataLad."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Report planned changes without modifying files.",
+    )
+    parser.add_argument(
+        "--n-cpus",
+        "--n_cpus",
+        type=int,
+        action="store",
+        dest="n_cpus",
+        default=1,
+        help="Number of workers used to read and plan independent file updates.",
+    )
+    return parser
+
+
 COMMANDS = [
     ("validate", _parse_validate, workflows.validate),
     ("bids-version", _parse_bids_version, workflows.bids_version),
@@ -1127,6 +1201,7 @@ COMMANDS = [
         _parse_remove_metadata_fields,
         workflows.remove_metadata_fields,
     ),
+    ("date-time-shift", _parse_date_time_shift, workflows.date_time_shift),
 ]
 
 
@@ -1179,8 +1254,8 @@ def _main(argv=None):
     args.pop("func")
 
     # Automatically set validation_scope='subject' when --participant-label is provided
-    if "participant_label" in args and "validation_scope" in args:
-        if args["participant_label"]:
-            args["validation_scope"] = "subject"
+    if "participant_label" in args and "validation_scope" in args and args["participant_label"]:
+        args["validation_scope"] = "subject"
 
-    options.func(**args)
+    result = options.func(**args)
+    return result if isinstance(result, int) else None

--- a/cubids/cli.py
+++ b/cubids/cli.py
@@ -1258,4 +1258,6 @@ def _main(argv=None):
         args["validation_scope"] = "subject"
 
     result = options.func(**args)
-    return result if isinstance(result, int) else None
+    # The console script exits with _main's return value; only genuine int exit
+    # codes may propagate (bool is an int subclass, so True would exit 1).
+    return result if isinstance(result, int) and not isinstance(result, bool) else None

--- a/cubids/constants.py
+++ b/cubids/constants.py
@@ -13,34 +13,31 @@ IMAGING_PARAMS : set of str
     List of metadata fields merged in `metadata_merge.py`.
 """
 
-ID_VARS = set(["EntitySet", "ParamGroup", "FilePath"])
-NON_KEY_ENTITIES = set(["subject", "session", "extension"])
+ID_VARS = {"EntitySet", "ParamGroup", "FilePath"}
+NON_KEY_ENTITIES = {"subject", "session", "extension"}
 # Multi-dimensional keys SliceTiming  XXX: what is this line about?
-IMAGING_PARAMS = set(
-    [
-        "ParallelReductionFactorInPlane",
-        "ParallelAcquisitionTechnique",
-        "ParallelAcquisitionTechnique",
-        "PartialFourier",
-        "PhaseEncodingDirection",
-        "EffectiveEchoSpacing",
-        "TotalReadoutTime",
-        "EchoTime",
-        "SliceEncodingDirection",
-        "DwellTime",
-        "FlipAngle",
-        "MultibandAccelerationFactor",
-        "RepetitionTime",
-        "VolumeTiming",
-        "NumberOfVolumesDiscardedByScanner",
-        "NumberOfVolumesDiscardedByUser",
-        "Obliquity",
-        "VoxelSizeDim1",
-        "VoxelSizeDim2",
-        "VoxelSizeDim3",
-        "Dim1Size",
-        "Dim2Size",
-        "Dim3Size",
-        "NumVolumes",
-    ]
-)
+IMAGING_PARAMS = {
+    "ParallelReductionFactorInPlane",
+    "ParallelAcquisitionTechnique",
+    "PartialFourier",
+    "PhaseEncodingDirection",
+    "EffectiveEchoSpacing",
+    "TotalReadoutTime",
+    "EchoTime",
+    "SliceEncodingDirection",
+    "DwellTime",
+    "FlipAngle",
+    "MultibandAccelerationFactor",
+    "RepetitionTime",
+    "VolumeTiming",
+    "NumberOfVolumesDiscardedByScanner",
+    "NumberOfVolumesDiscardedByUser",
+    "Obliquity",
+    "VoxelSizeDim1",
+    "VoxelSizeDim2",
+    "VoxelSizeDim3",
+    "Dim1Size",
+    "Dim2Size",
+    "Dim3Size",
+    "NumVolumes",
+}

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -1424,7 +1424,7 @@ class CuBIDS:
         # deal with IntendedFor Key!
         if "IntendedForKey" in relational:
             if "suggest_variant_rename" in relational["IntendedForKey"]:
-                if relational["FieldmapKey"]["suggest_variant_rename"]:
+                if relational["IntendedForKey"]["suggest_variant_rename"]:
                     # check if 'bool' or 'columns'
                     if relational["IntendedForKey"]["display_mode"] == "bool":
                         rename_cols.append("UsedAsFieldmap")

--- a/cubids/cubids.py
+++ b/cubids/cubids.py
@@ -38,7 +38,7 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 bids.config.set_option("extension_initial_dot", True)
 
 
-class CuBIDS(object):
+class CuBIDS:
     """The main CuBIDS class.
 
     Parameters
@@ -305,8 +305,8 @@ class CuBIDS(object):
             raise Exception("DataLad has not been initialized. use datalad_init()")
 
         statuses = self.datalad_handle.save(message=message or "CuBIDS Save", jobs=jobs)
-        saved_status = set([status["status"] for status in statuses])
-        if not saved_status == set(["ok"]):
+        saved_status = {status["status"] for status in statuses}
+        if not saved_status == {"ok"}:
             raise Exception("Failed to save in DataLad")
 
     def is_datalad_clean(self):
@@ -324,8 +324,8 @@ class CuBIDS(object):
         """
         if not self.datalad_ready:
             raise Exception("Datalad not initialized, can't determine status")
-        statuses = set([status["state"] for status in self.datalad_handle.status()])
-        return statuses == set(["clean"])
+        statuses = {status["state"] for status in self.datalad_handle.status()}
+        return statuses == {"clean"}
 
     def datalad_undo_last_commit(self):
         """Revert the most recent commit, remove it from history.
@@ -947,14 +947,13 @@ class CuBIDS(object):
 
         # save IntendedFor purges so that you can datalad run the
         # remove association file commands on a clean dataset
-        if self.use_datalad:
-            if not self.is_datalad_clean():
-                s1 = "Purged IntendedFor references to files "
-                s2 = "requested for removal"
-                message = s1 + s2
-                dl_jobs = n_cpus if n_cpus and n_cpus > 1 else 1
-                self.datalad_save(message=message, jobs=dl_jobs)
-                self._invalidate_index()
+        if self.use_datalad and not self.is_datalad_clean():
+            s1 = "Purged IntendedFor references to files "
+            s2 = "requested for removal"
+            message = s1 + s2
+            dl_jobs = n_cpus if n_cpus and n_cpus > 1 else 1
+            self.datalad_save(message=message, jobs=dl_jobs)
+            self._invalidate_index()
 
         # NOW WE WANT TO PURGE ALL ASSOCIATIONS
 
@@ -1240,22 +1239,22 @@ class CuBIDS(object):
             underscore.
         """
         sidecar_params = self.grouping_config.get("sidecar_params")
-        for mod in sidecar_params.keys():
+        for mod in sidecar_params:
             mod_dict = sidecar_params[mod]
-            for s_param in mod_dict.keys():
-                if s_param not in self.data_dict.keys():
+            for s_param in mod_dict:
+                if s_param not in self.data_dict:
                     self.data_dict[s_param] = {"Description": "Scanning Parameter"}
 
         relational_params = self.grouping_config.get("relational_params")
-        for r_param in relational_params.keys():
-            if r_param not in self.data_dict.keys():
+        for r_param in relational_params:
+            if r_param not in self.data_dict:
                 self.data_dict[r_param] = {"Description": "Scanning Parameter"}
 
         derived_params = self.grouping_config.get("derived_params")
-        for mod in derived_params.keys():
+        for mod in derived_params:
             mod_dict = derived_params[mod]
-            for d_param in mod_dict.keys():
-                if d_param not in self.data_dict.keys():
+            for d_param in mod_dict:
+                if d_param not in self.data_dict:
                     self.data_dict[d_param] = {"Description": "NIfTI Header Parameter"}
 
         # Manually add non-sidecar columns/descriptions to data_dict
@@ -1407,16 +1406,16 @@ class CuBIDS(object):
 
         rename_cols = []
         tolerance_cols = []
-        for col in sidecar.keys():
-            if "suggest_variant_rename" in sidecar[col].keys():
+        for col in sidecar:
+            if "suggest_variant_rename" in sidecar[col]:
                 if sidecar[col]["suggest_variant_rename"] and col in summary.columns:
                     rename_cols.append(col)
-                    if "tolerance" in sidecar[col].keys():
+                    if "tolerance" in sidecar[col]:
                         tolerance_cols.append(col)
 
         # deal with Fmap!
         if "FieldmapKey" in relational:
-            if "suggest_variant_rename" in relational["FieldmapKey"].keys():
+            if "suggest_variant_rename" in relational["FieldmapKey"]:
                 if relational["FieldmapKey"]["suggest_variant_rename"]:
                     # check if 'bool' or 'columns'
                     if relational["FieldmapKey"]["display_mode"] == "bool":
@@ -1424,7 +1423,7 @@ class CuBIDS(object):
 
         # deal with IntendedFor Key!
         if "IntendedForKey" in relational:
-            if "suggest_variant_rename" in relational["IntendedForKey"].keys():
+            if "suggest_variant_rename" in relational["IntendedForKey"]:
                 if relational["FieldmapKey"]["suggest_variant_rename"]:
                     # check if 'bool' or 'columns'
                     if relational["IntendedForKey"]["display_mode"] == "bool":
@@ -1559,7 +1558,7 @@ class CuBIDS(object):
                 continue
 
             json_file = [x for x in bidsjson_file if "json" in x.filename]
-            if not len(json_file) == 1:
+            if len(json_file) != 1:
                 print("FOUND IRREGULAR ASSOCIATIONS")
 
             else:
@@ -1592,20 +1591,19 @@ class CuBIDS(object):
             while processing a file.
         """
         found_fields = set()
-        for json_file in Path(self.path).rglob("*.json"):
-            if ".git" not in str(json_file):
-                try:
-                    with open(json_file, "r", encoding="utf-8") as jsonr:
-                        content = jsonr.read().strip()
-                        if not content:
-                            print(f"Empty file: {json_file}")
-                            continue
-                        metadata = json.loads(content)
-                    found_fields.update(metadata.keys())
-                except json.JSONDecodeError as e:
-                    warnings.warn(f"Error decoding JSON in {json_file}: {e}")
-                except Exception as e:
-                    warnings.warn(f"Unexpected error with file {json_file}: {e}")
+        for json_file in utils.find_json_files(self.path):
+            try:
+                with open(json_file, "r", encoding="utf-8") as jsonr:
+                    content = jsonr.read().strip()
+                    if not content:
+                        print(f"Empty file: {json_file}")
+                        continue
+                    metadata = json.loads(content)
+                found_fields.update(metadata.keys())
+            except json.JSONDecodeError as e:
+                warnings.warn(f"Error decoding JSON in {json_file}: {e}")
+            except Exception as e:
+                warnings.warn(f"Unexpected error with file {json_file}: {e}")
 
         return sorted(found_fields)
 
@@ -1628,19 +1626,18 @@ class CuBIDS(object):
         if not remove_fields:
             return
 
-        for json_file in tqdm(Path(self.path).rglob("*.json")):
-            if ".git" not in str(json_file):
-                with open(json_file, "r") as jsonr:
-                    metadata = json.load(jsonr)
+        for json_file in tqdm(utils.find_json_files(self.path)):
+            with open(json_file, "r") as jsonr:
+                metadata = json.load(jsonr)
 
-                offending_keys = remove_fields.intersection(metadata.keys())
-                if not offending_keys:
-                    continue
+            offending_keys = remove_fields.intersection(metadata.keys())
+            if not offending_keys:
+                continue
 
-                for key in offending_keys:
-                    del metadata[key]
-                with open(json_file, "w") as jsonr:
-                    json.dump(metadata, jsonr, indent=4)
+            for key in offending_keys:
+                del metadata[key]
+            with open(json_file, "w") as jsonr:
+                json.dump(metadata, jsonr, indent=4)
 
         self._invalidate_index()
 
@@ -1686,26 +1683,26 @@ def _add_metadata_single_nifti(nifti_path):
             print("Error parsing this sidecar: ", sidecar)
             return
 
-        if "Obliquity" not in data.keys():
+        if "Obliquity" not in data:
             data["Obliquity"] = str(obliquity)
-        if "VoxelSizeDim1" not in data.keys():
+        if "VoxelSizeDim1" not in data:
             data["VoxelSizeDim1"] = float(voxel_sizes[0])
-        if "VoxelSizeDim2" not in data.keys():
+        if "VoxelSizeDim2" not in data:
             data["VoxelSizeDim2"] = float(voxel_sizes[1])
-        if "VoxelSizeDim3" not in data.keys():
+        if "VoxelSizeDim3" not in data:
             data["VoxelSizeDim3"] = float(voxel_sizes[2])
-        if "Dim1Size" not in data.keys():
+        if "Dim1Size" not in data:
             data["Dim1Size"] = matrix_dims[0]
-        if "Dim2Size" not in data.keys():
+        if "Dim2Size" not in data:
             data["Dim2Size"] = matrix_dims[1]
-        if "Dim3Size" not in data.keys():
+        if "Dim3Size" not in data:
             data["Dim3Size"] = matrix_dims[2]
-        if "NumVolumes" not in data.keys():
+        if "NumVolumes" not in data:
             if img.ndim == 4:
                 data["NumVolumes"] = matrix_dims[3]
             elif img.ndim == 3:
                 data["NumVolumes"] = 1
-        if "ImageOrientation" not in data.keys():
+        if "ImageOrientation" not in data:
             orient = nb.orientations.aff2axcodes(img.affine)
             orient = [str(orientation) for orientation in orient]
             joined = "".join(orient) + "+"

--- a/cubids/date_time_shift.py
+++ b/cubids/date_time_shift.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import io
 import json
 import logging
+import os
 import re
+import stat
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -489,7 +491,14 @@ def _log_changes(
 
 def _write_updates(scans_updates: list[_ScansUpdate], json_updates: list[_JSONUpdate]) -> None:
     """Write validated output after preflight has completed successfully."""
-    for update in [*scans_updates, *json_updates]:
+    updates = [*scans_updates, *json_updates]
+    for update in updates:
+        if os.access(update.path, os.W_OK):
+            continue
+        update.path.chmod(update.path.stat().st_mode | stat.S_IWUSR)
+        logger.info("Made file writable: %s", update.path)
+
+    for update in updates:
         update.path.write_text(update.contents, encoding="utf-8")
 
 

--- a/cubids/date_time_shift.py
+++ b/cubids/date_time_shift.py
@@ -7,6 +7,7 @@ sidecars.
 
 from __future__ import annotations
 
+import csv
 import io
 import json
 import logging
@@ -41,6 +42,16 @@ _JSON_SCALAR_TIME_PATHS = (
 _JSON_TIME_ARRAY_PATHS = (
     ("time", "samples", "AcquisitionTime"),
     ("time", "samples", "ContentTime"),
+)
+# Date-bearing sidecar fields this command does not rewrite. Their presence is
+# surfaced as a warning so identifiable dates are not silently left behind.
+_JSON_DATE_FIELD_PATHS = (
+    ("AcquisitionDateTime",),
+    ("global", "const", "AcquisitionDate"),
+    ("global", "const", "AcquisitionDateTime"),
+    ("global", "const", "ContentDate"),
+    ("global", "const", "SeriesDate"),
+    ("global", "const", "StudyDate"),
 )
 
 _Input = TypeVar("_Input")
@@ -103,6 +114,15 @@ def parse_iso_datetime(value: str) -> datetime | None:
     if value.endswith("Z"):
         value = value[:-1] + "+00:00"
 
+    # Python < 3.11 only accepts fractional seconds with exactly 3 or 6 digits,
+    # so normalize the fraction to 6 digits before parsing.
+    value = re.sub(
+        r"\.(\d+)",
+        lambda match: "." + match.group(1)[:6].ljust(6, "0"),
+        value,
+        count=1,
+    )
+
     try:
         return datetime.fromisoformat(value)
     except ValueError:
@@ -146,6 +166,11 @@ def parse_time_string(value: str) -> time | None:
         if 0 <= hour <= 23 and 0 <= minute <= 59 and 0 <= second <= 59:
             return time(hour=hour, minute=minute, second=second, microsecond=microsecond)
         return None
+
+    # DICOM times stored as JSON numbers lose their leading zero (e.g. 91530.0
+    # for 09:15:30); restore it so morning times parse like afternoon times.
+    if re.match(r"^\d{5}(?:\.\d+)?$", value):
+        value = "0" + value
 
     compact_time = re.match(_COMPACT_TIME_PATTERN, value)
     if compact_time:
@@ -201,6 +226,9 @@ def _read_scans_table(scans_file: Path) -> tuple[_ScansTable | None, str | None]
             sep="\t",
             dtype=str,
             keep_default_na=False,
+            # BIDS TSVs do not use quoting; QUOTE_NONE keeps quote characters
+            # in untouched columns byte-identical through the rewrite.
+            quoting=csv.QUOTE_NONE,
         )
     except (
         OSError,
@@ -260,8 +288,6 @@ def _plan_scans_update(
         return None, []
 
     subject_anchor = subject_anchors.get(_subject_from_scans_path(table.path))
-    if subject_anchor is None:
-        return None, []
 
     updated_times = table.data["acq_time"].copy()
     changes = []
@@ -274,6 +300,11 @@ def _plan_scans_update(
                 warnings.append(
                     f"Unparseable acq_time in {table.path}, row {index + 2}: {original_value}"
                 )
+            continue
+
+        # A parseable value implies the subject has an anchor; this guard only
+        # keeps the unparseable-value warnings above flowing when it does not.
+        if subject_anchor is None:
             continue
 
         rounded_datetime = round_datetime_to_nearest_hour(acquisition_datetime)
@@ -300,7 +331,7 @@ def _plan_scans_update(
     updated_data = table.data.copy()
     updated_data["acq_time"] = updated_times
     contents = io.StringIO()
-    updated_data.to_csv(contents, sep="\t", index=False)
+    updated_data.to_csv(contents, sep="\t", index=False, quoting=csv.QUOTE_NONE)
     return (
         _ScansUpdate(path=table.path, contents=contents.getvalue(), changes=changes),
         warnings,
@@ -430,6 +461,14 @@ def _plan_json_update(
         field_changes, field_warnings = _plan_json_time_array(data, field_path)
         changes.extend(field_changes)
         warnings.extend(field_warnings)
+    for field_path in _JSON_DATE_FIELD_PATHS:
+        parent = _get_json_parent(data, field_path)
+        if parent is not None and field_path[-1] in parent:
+            warnings.append(
+                f"Date field {'.'.join(field_path)} is not de-identified by this command"
+            )
+
+    warnings = [f"{json_file}: {warning}" for warning in warnings]
 
     if not changes:
         return None, "\n".join(warnings) if warnings else None, None
@@ -489,7 +528,11 @@ def _log_changes(
             logger.info("    %s: %s -> %s", change.field_path, change.before, change.after)
 
 
-def _write_updates(scans_updates: list[_ScansUpdate], json_updates: list[_JSONUpdate]) -> None:
+def _write_updates(
+    scans_updates: list[_ScansUpdate],
+    json_updates: list[_JSONUpdate],
+    written: list[_ScansUpdate | _JSONUpdate],
+) -> None:
     """Write validated output after preflight has completed successfully."""
     updates = [*scans_updates, *json_updates]
     for update in updates:
@@ -500,6 +543,7 @@ def _write_updates(scans_updates: list[_ScansUpdate], json_updates: list[_JSONUp
 
     for update in updates:
         update.path.write_text(update.contents, encoding="utf-8")
+        written.append(update)
 
 
 def date_time_shift(bids_dir: Path, dry_run: bool = False, n_cpus: int = 1) -> int:
@@ -558,10 +602,15 @@ def date_time_shift(bids_dir: Path, dry_run: bool = False, n_cpus: int = 1) -> i
     if dry_run:
         _log_changes(scans_updates, json_updates, dry_run=True)
     else:
+        written: list[_ScansUpdate | _JSONUpdate] = []
         try:
-            _write_updates(scans_updates, json_updates)
+            _write_updates(scans_updates, json_updates, written)
         except OSError as error:
             logger.error("Could not write date/time shift updates: %s", error)
+            if written:
+                logger.error("%d files were already updated before the failure:", len(written))
+                for update in written:
+                    logger.error("    %s", update.path)
             return 1
         _log_changes(scans_updates, json_updates, dry_run=False)
 

--- a/cubids/date_time_shift.py
+++ b/cubids/date_time_shift.py
@@ -1,0 +1,571 @@
+"""Date/time anonymization utilities for BIDS datasets.
+
+This module shifts acquisition dates in subject- and session-level
+``*_scans.tsv`` files and rounds acquisition times in scans tables and JSON
+sidecars.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+from collections import defaultdict
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+from typing import TypeVar
+
+import pandas as pd
+
+from cubids.utils import find_json_files
+
+logger = logging.getLogger("cubids-cli")
+
+NEW_BASE_DATE = date(1800, 1, 1)
+_COMPACT_TIME_PATTERN = (
+    r"^(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2})(?:\.(?P<fraction>\d{1,6}))?$"
+)
+
+_JSON_SCALAR_TIME_PATHS = (
+    ("AcquisitionTime",),
+    ("global", "const", "PerformedProcedureStepStartTime"),
+    ("global", "const", "SeriesTime"),
+    ("global", "const", "StudyTime"),
+)
+_JSON_TIME_ARRAY_PATHS = (
+    ("time", "samples", "AcquisitionTime"),
+    ("time", "samples", "ContentTime"),
+)
+
+_Input = TypeVar("_Input")
+_Output = TypeVar("_Output")
+
+
+@dataclass
+class _ScansTable:
+    """A scans table read during validation."""
+
+    path: Path
+    data: pd.DataFrame
+
+
+@dataclass
+class _ScansChange:
+    """A planned change to one scans.tsv acquisition time."""
+
+    row_number: int
+    before: str
+    after: str
+
+
+@dataclass
+class _ScansUpdate:
+    """A validated scans.tsv rewrite and its changes."""
+
+    path: Path
+    contents: str
+    changes: list[_ScansChange]
+
+
+@dataclass
+class _JSONChange:
+    """A planned change to a JSON acquisition or DICOM-derived time value."""
+
+    field_path: str
+    before: str
+    after: str
+
+
+@dataclass
+class _JSONUpdate:
+    """A validated JSON rewrite and its acquisition-time changes."""
+
+    path: Path
+    contents: str
+    changes: list[_JSONChange]
+
+
+def parse_iso_datetime(value: str) -> datetime | None:
+    """Parse an ISO-8601 datetime used in a scans.tsv ``acq_time`` field."""
+    if value is None:
+        return None
+
+    value = str(value).strip()
+    if not value or value.lower() == "n/a":
+        return None
+
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def round_datetime_to_nearest_hour(acquisition_datetime: datetime) -> datetime:
+    """Round a datetime to the nearest hour, with 30 minutes rounding up."""
+    offset_microseconds = (
+        acquisition_datetime.minute * 60 + acquisition_datetime.second
+    ) * 1_000_000 + acquisition_datetime.microsecond
+    rounded = acquisition_datetime.replace(minute=0, second=0, microsecond=0)
+
+    if offset_microseconds >= 30 * 60 * 1_000_000:
+        rounded += timedelta(hours=1)
+
+    return rounded
+
+
+def parse_time_string(value: str) -> time | None:
+    """Parse supported BIDS JSON ``AcquisitionTime`` representations."""
+    if value is None:
+        return None
+
+    value = str(value).strip()
+    if not value:
+        return None
+
+    colon_time = re.match(
+        r"^(?P<hour>\d{1,2}):(?P<minute>\d{1,2})"
+        r"(?::(?P<second>\d{1,2})(?:\.(?P<fraction>\d{1,9}))?)?$",
+        value,
+    )
+    if colon_time:
+        hour = int(colon_time.group("hour"))
+        minute = int(colon_time.group("minute"))
+        second = int(colon_time.group("second") or 0)
+        fraction = colon_time.group("fraction")
+        microsecond = int(fraction[:6].ljust(6, "0")) if fraction else 0
+
+        if 0 <= hour <= 23 and 0 <= minute <= 59 and 0 <= second <= 59:
+            return time(hour=hour, minute=minute, second=second, microsecond=microsecond)
+        return None
+
+    compact_time = re.match(_COMPACT_TIME_PATTERN, value)
+    if compact_time:
+        hour = int(compact_time.group("hour"))
+        minute = int(compact_time.group("minute"))
+        second = int(compact_time.group("second"))
+        fraction = compact_time.group("fraction")
+        microsecond = int(fraction.ljust(6, "0")) if fraction else 0
+
+        if 0 <= hour <= 23 and 0 <= minute <= 59 and 0 <= second <= 59:
+            return time(hour=hour, minute=minute, second=second, microsecond=microsecond)
+
+    return None
+
+
+def round_time_to_nearest_hour(acquisition_time: time) -> time:
+    """Round a time to the nearest hour, wrapping 23:30 to 00:00:00."""
+    offset_microseconds = (
+        acquisition_time.minute * 60 + acquisition_time.second
+    ) * 1_000_000 + acquisition_time.microsecond
+    hour = acquisition_time.hour
+
+    if offset_microseconds >= 30 * 60 * 1_000_000:
+        hour = (hour + 1) % 24
+
+    return time(hour=hour)
+
+
+def _subject_from_scans_path(path: Path) -> str:
+    """Return the ``sub-*`` directory that contains a scans table."""
+    for parent in path.parents:
+        if parent.name.startswith("sub-"):
+            return parent.name
+    raise ValueError(f"Scans table is not stored below a subject directory: {path}")
+
+
+def _parallel_map(
+    function: Callable[[_Input], _Output], items: list[_Input], n_cpus: int
+) -> list[_Output]:
+    """Run independent I/O and planning operations using the requested workers."""
+    if n_cpus == 1:
+        return [function(item) for item in items]
+
+    with ThreadPoolExecutor(max_workers=n_cpus) as executor:
+        return list(executor.map(function, items))
+
+
+def _read_scans_table(scans_file: Path) -> tuple[_ScansTable | None, str | None]:
+    """Read one scans table and return a validation error rather than raising it."""
+    try:
+        data = pd.read_csv(
+            scans_file,
+            sep="\t",
+            dtype=str,
+            keep_default_na=False,
+        )
+    except (
+        OSError,
+        UnicodeDecodeError,
+        pd.errors.EmptyDataError,
+        pd.errors.ParserError,
+    ) as error:
+        return None, f"Could not read {scans_file}: {error}"
+
+    return _ScansTable(path=scans_file, data=data), None
+
+
+def _read_scans_tables(
+    scans_files: list[Path], n_cpus: int
+) -> tuple[list[_ScansTable], list[str]]:
+    """Read all scans tables before any output file is changed."""
+    tables = []
+    errors = []
+
+    for table, error in _parallel_map(_read_scans_table, scans_files, n_cpus):
+        if error:
+            errors.append(error)
+        elif table is not None:
+            tables.append(table)
+
+    return tables, errors
+
+
+def _get_subject_anchors(tables: list[_ScansTable]) -> dict[str, date]:
+    """Determine each subject's earliest rounded acquisition date."""
+    subject_dates: defaultdict[str, list[date]] = defaultdict(list)
+
+    for table in tables:
+        if "acq_time" not in table.data.columns:
+            continue
+
+        subject = _subject_from_scans_path(table.path)
+        for value in table.data["acq_time"]:
+            acquisition_datetime = parse_iso_datetime(value)
+            if acquisition_datetime is not None:
+                subject_dates[subject].append(
+                    round_datetime_to_nearest_hour(acquisition_datetime).date()
+                )
+
+    return {
+        subject: min(acquisition_dates)
+        for subject, acquisition_dates in subject_dates.items()
+        if acquisition_dates
+    }
+
+
+def _plan_scans_update(
+    table: _ScansTable, subject_anchors: dict[str, date]
+) -> tuple[_ScansUpdate | None, list[str]]:
+    """Plan the independent updates for one scans table."""
+    if "acq_time" not in table.data.columns:
+        return None, []
+
+    subject_anchor = subject_anchors.get(_subject_from_scans_path(table.path))
+    if subject_anchor is None:
+        return None, []
+
+    updated_times = table.data["acq_time"].copy()
+    changes = []
+    warnings = []
+    for index, value in table.data["acq_time"].items():
+        original_value = str(value)
+        acquisition_datetime = parse_iso_datetime(original_value)
+        if acquisition_datetime is None:
+            if original_value.strip() and original_value.strip().lower() != "n/a":
+                warnings.append(
+                    f"Unparseable acq_time in {table.path}, row {index + 2}: {original_value}"
+                )
+            continue
+
+        rounded_datetime = round_datetime_to_nearest_hour(acquisition_datetime)
+        day_offset = (rounded_datetime.date() - subject_anchor).days
+        shifted_datetime = datetime.combine(
+            NEW_BASE_DATE + timedelta(days=day_offset),
+            rounded_datetime.time(),
+        )
+        new_value = shifted_datetime.strftime("%Y-%m-%dT%H:%M:%S")
+
+        if new_value != original_value:
+            updated_times.at[index] = new_value
+            changes.append(
+                _ScansChange(
+                    row_number=index + 2,
+                    before=original_value,
+                    after=new_value,
+                )
+            )
+
+    if not changes:
+        return None, warnings
+
+    updated_data = table.data.copy()
+    updated_data["acq_time"] = updated_times
+    contents = io.StringIO()
+    updated_data.to_csv(contents, sep="\t", index=False)
+    return (
+        _ScansUpdate(path=table.path, contents=contents.getvalue(), changes=changes),
+        warnings,
+    )
+
+
+def _plan_scans_updates(
+    tables: list[_ScansTable], n_cpus: int
+) -> tuple[list[_ScansUpdate], list[str]]:
+    """Create scans.tsv updates after finding each subject's rounded date anchor."""
+    subject_anchors = _get_subject_anchors(tables)
+    updates = []
+    warnings = []
+
+    def plan_update(table: _ScansTable) -> tuple[_ScansUpdate | None, list[str]]:
+        return _plan_scans_update(table, subject_anchors)
+
+    for update, table_warnings in _parallel_map(plan_update, tables, n_cpus):
+        warnings.extend(table_warnings)
+        if update is not None:
+            updates.append(update)
+
+    return updates, warnings
+
+
+def _get_json_parent(data: dict, field_path: tuple[str, ...]) -> dict | None:
+    """Return the mapping that owns a nested JSON field, if present."""
+    parent = data
+    for key in field_path[:-1]:
+        value = parent.get(key)
+        if not isinstance(value, dict):
+            return None
+        parent = value
+    return parent
+
+
+def _round_json_time_value(value, field_path: str) -> tuple[str | None, str | None]:
+    """Round one JSON time value or return a warning when it is unparseable."""
+    original_time = "" if value is None else str(value)
+    acquisition_time = parse_time_string(original_time)
+    if acquisition_time is None:
+        return None, f"Unparseable {field_path}: {value}"
+
+    new_value = round_time_to_nearest_hour(acquisition_time).strftime("%H:%M:%S")
+    if new_value == original_time:
+        return None, None
+    return new_value, None
+
+
+def _plan_json_scalar_time(
+    data: dict, field_path: tuple[str, ...]
+) -> tuple[list[_JSONChange], list[str]]:
+    """Plan a top-level or nested scalar JSON time update."""
+    parent = _get_json_parent(data, field_path)
+    field_name = ".".join(field_path)
+    if parent is None or field_path[-1] not in parent:
+        return [], []
+
+    original_value = parent[field_path[-1]]
+    new_value, warning = _round_json_time_value(original_value, field_name)
+    if warning:
+        return [], [warning]
+    if new_value is None:
+        return [], []
+
+    parent[field_path[-1]] = new_value
+    return [_JSONChange(field_path=field_name, before=str(original_value), after=new_value)], []
+
+
+def _plan_json_time_array(
+    data: dict, field_path: tuple[str, ...]
+) -> tuple[list[_JSONChange], list[str]]:
+    """Plan element-wise updates for a JSON array of time values."""
+    parent = _get_json_parent(data, field_path)
+    field_name = ".".join(field_path)
+    if parent is None or field_path[-1] not in parent:
+        return [], []
+
+    values = parent[field_path[-1]]
+    if not isinstance(values, list):
+        return [], [f"Expected {field_name} to be an array of time values"]
+
+    changes = []
+    warnings = []
+    updated_values = values.copy()
+    for index, original_value in enumerate(values):
+        element_path = f"{field_name}[{index}]"
+        new_value, warning = _round_json_time_value(original_value, element_path)
+        if warning:
+            warnings.append(warning)
+            continue
+        if new_value is not None:
+            updated_values[index] = new_value
+            changes.append(
+                _JSONChange(
+                    field_path=element_path,
+                    before=str(original_value),
+                    after=new_value,
+                )
+            )
+
+    if changes:
+        parent[field_path[-1]] = updated_values
+    return changes, warnings
+
+
+def _plan_json_update(
+    json_file: Path,
+) -> tuple[_JSONUpdate | None, str | None, str | None]:
+    """Validate and plan the independent update for one JSON file."""
+    try:
+        with json_file.open(encoding="utf-8") as file_handle:
+            data = json.load(file_handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        return None, None, f"Could not read JSON {json_file}: {error}"
+
+    if not isinstance(data, dict):
+        return None, None, None
+
+    changes = []
+    warnings = []
+    for field_path in _JSON_SCALAR_TIME_PATHS:
+        field_changes, field_warnings = _plan_json_scalar_time(data, field_path)
+        changes.extend(field_changes)
+        warnings.extend(field_warnings)
+    for field_path in _JSON_TIME_ARRAY_PATHS:
+        field_changes, field_warnings = _plan_json_time_array(data, field_path)
+        changes.extend(field_changes)
+        warnings.extend(field_warnings)
+
+    if not changes:
+        return None, "\n".join(warnings) if warnings else None, None
+
+    contents = io.StringIO()
+    json.dump(data, contents, ensure_ascii=False, indent=4)
+    contents.write("\n")
+    return (
+        _JSONUpdate(
+            path=json_file,
+            contents=contents.getvalue(),
+            changes=changes,
+        ),
+        "\n".join(warnings) if warnings else None,
+        None,
+    )
+
+
+def _plan_json_updates(
+    json_files: list[Path], n_cpus: int
+) -> tuple[list[_JSONUpdate], list[str], list[str]]:
+    """Validate all JSON files and prepare supported acquisition-time updates."""
+    updates = []
+    warnings = []
+    errors = []
+
+    for update, warning, error in _parallel_map(_plan_json_update, json_files, n_cpus):
+        if update is not None:
+            updates.append(update)
+        if warning:
+            warnings.append(warning)
+        if error:
+            errors.append(error)
+
+    return updates, warnings, errors
+
+
+def _log_changes(
+    scans_updates: list[_ScansUpdate], json_updates: list[_JSONUpdate], dry_run: bool
+) -> None:
+    """Report all changed values using the CLI logger."""
+    action = "WOULD CHANGE" if dry_run else "CHANGED"
+
+    for update in scans_updates:
+        logger.info("[%s] %s", action, update.path)
+        for change in update.changes:
+            logger.info(
+                "    row %d: acq_time: %s -> %s",
+                change.row_number,
+                change.before,
+                change.after,
+            )
+
+    for update in json_updates:
+        logger.info("[%s] %s", action, update.path)
+        for change in update.changes:
+            logger.info("    %s: %s -> %s", change.field_path, change.before, change.after)
+
+
+def _write_updates(scans_updates: list[_ScansUpdate], json_updates: list[_JSONUpdate]) -> None:
+    """Write validated output after preflight has completed successfully."""
+    for update in [*scans_updates, *json_updates]:
+        update.path.write_text(update.contents, encoding="utf-8")
+
+
+def date_time_shift(bids_dir: Path, dry_run: bool = False, n_cpus: int = 1) -> int:
+    """Shift BIDS acquisition dates and round acquisition times in place.
+
+    Each subject's earliest rounded scans.tsv acquisition date is shifted to
+    ``1800-01-01``. Calendar-day offsets are retained, and scans.tsv and JSON
+    acquisition times are rounded to the nearest hour. This includes top-level
+    and dcmmeta-derived JSON acquisition-time fields. Input files are all read
+    and validated before any planned updates are written.
+
+    Parameters
+    ----------
+    bids_dir : :obj:`pathlib.Path`
+        Root of the BIDS dataset to update.
+    dry_run : :obj:`bool`
+        Report planned changes without writing files.
+    n_cpus : :obj:`int`
+        Number of workers used to read and plan independent file updates.
+
+    Returns
+    -------
+    int
+        Zero on success, one if metadata cannot be validated or written, and
+        two when ``bids_dir`` is not a directory.
+    """
+    if not bids_dir.is_dir():
+        logger.error("BIDS directory does not exist or is not a directory: %s", bids_dir)
+        return 2
+
+    if n_cpus < 1:
+        logger.error("n_cpus must be at least 1; received %d.", n_cpus)
+        return 2
+
+    scans_files = sorted(
+        path
+        for pattern in ("sub-*/*_scans.tsv", "sub-*/ses-*/*_scans.tsv")
+        for path in bids_dir.glob(pattern)
+        if path.is_file()
+    )
+    json_files = find_json_files(bids_dir)
+    tables, scans_errors = _read_scans_tables(scans_files, n_cpus)
+    scans_updates, scans_warnings = _plan_scans_updates(tables, n_cpus)
+    json_updates, json_warnings, json_errors = _plan_json_updates(json_files, n_cpus)
+    validation_errors = [*scans_errors, *json_errors]
+
+    for warning in [*scans_warnings, *json_warnings]:
+        logger.warning(warning)
+
+    if validation_errors:
+        logger.error("Date/time shift validation failed; no files were modified.")
+        for error in validation_errors:
+            logger.error(error)
+        return 1
+
+    if dry_run:
+        _log_changes(scans_updates, json_updates, dry_run=True)
+    else:
+        try:
+            _write_updates(scans_updates, json_updates)
+        except OSError as error:
+            logger.error("Could not write date/time shift updates: %s", error)
+            return 1
+        _log_changes(scans_updates, json_updates, dry_run=False)
+
+    scans_changes = sum(len(update.changes) for update in scans_updates)
+    json_changes = sum(len(update.changes) for update in json_updates)
+    logger.info(
+        "%s %d scans.tsv files and %d JSON files; %d scans.tsv acq_time values and "
+        "%d JSON time values %s.",
+        "Checked" if dry_run else "Processed",
+        len(scans_files),
+        len(json_files),
+        scans_changes,
+        json_changes,
+        "would change" if dry_run else "changed",
+    )
+    return 0

--- a/cubids/indexing.py
+++ b/cubids/indexing.py
@@ -114,9 +114,7 @@ def _anyof_to_arrow(branches, prefer_scalar):
             scalar = pa.float64()
         elif btype == "integer":
             scalar = pa.int32()
-        elif btype == "string":
-            scalar = pa.string()
-        elif btype == "boolean":
+        elif btype == "string" or btype == "boolean":
             scalar = pa.string()
 
     if prefer_scalar and scalar is not None:
@@ -192,7 +190,7 @@ def build_metadata_type_map(bids_schema, grouping_config):
     type_map = {}
 
     for section in ("sidecar_params", "derived_params"):
-        for _modality, params in grouping_config.get(section, {}).items():
+        for params in grouping_config.get(section, {}).values():
             for param_name, param_props in params.items():
                 if param_name in type_map:
                     continue
@@ -575,10 +573,10 @@ def load_or_build_index(root, bids_schema, grouping_config, cache_dir=None, use_
                     break
         if not stale:
             table = pq.read_table(cache_path)
-            print(f"Loaded CuBIDS index from cache ({len(table)} files). " f"Cache: {cache_path}")
+            print(f"Loaded CuBIDS index from cache ({len(table)} files). Cache: {cache_path}")
             return table
         else:
-            print("CuBIDS index cache is stale (dataset has been modified). " "Rebuilding...")
+            print("CuBIDS index cache is stale (dataset has been modified). Rebuilding...")
     else:
         print("No CuBIDS index cache found. Building index...")
 
@@ -718,9 +716,8 @@ def compute_entity_sets(table, non_key_entities, entity_column_names=None):
     for name in niftis.column_names:
         if name in skip:
             continue
-        if entity_column_names is not None:
-            if name not in entity_column_names:
-                continue
+        if entity_column_names is not None and name not in entity_column_names:
+            continue
         entity_cols.append(name)
 
     paths = niftis.column("path").to_pylist()

--- a/cubids/metadata_merge.py
+++ b/cubids/metadata_merge.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from cubids.constants import IMAGING_PARAMS
 
-DIRECT_IMAGING_PARAMS = IMAGING_PARAMS - set(["NSliceTimes"])
+DIRECT_IMAGING_PARAMS = IMAGING_PARAMS - {"NSliceTimes"}
 
 
 def check_merging_operations(action_tsv, raise_on_error=False):
@@ -45,13 +45,9 @@ def check_merging_operations(action_tsv, raise_on_error=False):
     overwrite_merges = []
     sdc_incompatible = []
 
-    sdc_cols = set(
-        [
-            col
-            for col in actions.columns
-            if col.startswith("IntendedForKey") or col.startswith("FieldmapKey")
-        ]
-    )
+    sdc_cols = {
+        col for col in actions.columns if col.startswith(("IntendedForKey", "FieldmapKey"))
+    }
 
     def _check_sdc_cols(meta1, meta2):
         return {key: meta1[key] for key in sdc_cols} == {key: meta2[key] for key in sdc_cols}
@@ -149,7 +145,7 @@ def merge_without_overwrite(source_meta, dest_meta_orig, raise_on_error=False):
     # copy the original json params
     dest_meta = deepcopy(dest_meta_orig)
 
-    if not source_meta.get("NSliceTimes") == dest_meta.get("NSliceTimes"):
+    if source_meta.get("NSliceTimes") != dest_meta.get("NSliceTimes"):
         if raise_on_error:
             raise Exception(
                 "Value for NSliceTimes is %d in destination "
@@ -268,7 +264,7 @@ def merge_json_into_json(from_file, to_file, raise_on_error=False):
         return 255
 
     # Only write if the data has changed
-    if not merged_metadata == orig_dest_metadata:
+    if merged_metadata != orig_dest_metadata:
         print("OVERWRITING", to_file)
         with open(to_file, "w") as tofw:
             json.dump(merged_metadata, tofw, indent=4)

--- a/cubids/tests/test_apply.py
+++ b/cubids/tests/test_apply.py
@@ -258,4 +258,6 @@ def test_cubids_apply_intendedfor_large_dataset(tmp_path, build_bids_dataset, su
     with open(fmap_json) as f:
         metadata = json.load(f)
 
-    assert metadata["IntendedFor"] == ["ses-01/dwi/sub-ABC_ses-01_acq-VAR_dir-AP_run-01_dwi.nii.gz"]
+    assert metadata["IntendedFor"] == [
+        "ses-01/dwi/sub-ABC_ses-01_acq-VAR_dir-AP_run-01_dwi.nii.gz"
+    ]

--- a/cubids/tests/test_bond.py
+++ b/cubids/tests/test_bond.py
@@ -73,7 +73,7 @@ def test_ok_json_merge(tmp_path):
 
     merge_return = merge_json_into_json(source_json, dest_json)
     assert merge_return == 0
-    assert not _get_json_string(dest_json) == orig_dest_json_content
+    assert _get_json_string(dest_json) != orig_dest_json_content
 
 
 def test_ok_json_merge_cli(tmp_path):
@@ -109,7 +109,7 @@ def test_ok_json_merge_cli(tmp_path):
     assert os.path.isfile(dest_json)
     merge_proc = subprocess.run(["cubids", "bids-sidecar-merge", str(source_json), str(dest_json)])
     assert merge_proc.returncode == 0
-    assert not _get_json_string(dest_json) == orig_dest_json_content
+    assert _get_json_string(dest_json) != orig_dest_json_content
 
 
 def test_get_param_groups(tmp_path):
@@ -185,8 +185,7 @@ def test_purge_no_datalad(tmp_path):
     # create and save .txt with list of scans
     purge_path = str(tmp_path / "purge_scans.txt")
     with open(purge_path, "w") as filehandle:
-        for listitem in scans:
-            filehandle.write(f"{listitem}\n")
+        filehandle.writelines(f"{listitem}\n" for listitem in scans)
 
     bod = CuBIDS(data_root / "complete", use_datalad=False)
 
@@ -253,8 +252,7 @@ def test_purge(tmp_path):
     purge_path = str(tmp_path / "purge_scans.txt")
 
     with open(purge_path, "w") as filehandle:
-        for listitem in scans:
-            filehandle.write(f"{listitem}\n")
+        filehandle.writelines(f"{listitem}\n" for listitem in scans)
     bod = CuBIDS(data_root / "complete", use_datalad=True)
     bod.datalad_save()
 
@@ -465,7 +463,7 @@ def test_tsv_merge_no_datalad(tmp_path):
 
     bod.apply_tsv_changes(valid_tsv_file, original_files_tsv, str(tmp_path / "ok_modified"))
 
-    assert not file_hash(original_summary_tsv) == file_hash(tmp_path / "ok_modified_summary.tsv")
+    assert file_hash(original_summary_tsv) != file_hash(tmp_path / "ok_modified_summary.tsv")
 
     # Add an illegal merge to MergeInto
     summary_df.loc[cant_merge_echotime_dwi_row, "MergeInto"] = summary_df.ParamGroup[
@@ -524,7 +522,7 @@ def test_tsv_merge_changes(tmp_path):
     for _, row in applied_files_df.iterrows():
         fp = row["FilePath"]
         if fp in odd:
-            if fp in occurrences.keys():
+            if fp in occurrences:
                 occurrences[fp].append(row["KeyParamGroup"])
             else:
                 occurrences[fp] = [row["KeyParamGroup"]]
@@ -577,7 +575,7 @@ def test_tsv_merge_changes(tmp_path):
     # about to merge
     bod.apply_tsv_changes(valid_tsv_file, original_files_tsv, str(tmp_path / "ok_modified"))
 
-    assert not file_hash(original_summary_tsv) == file_hash(tmp_path / "ok_modified_summary.tsv")
+    assert file_hash(original_summary_tsv) != file_hash(tmp_path / "ok_modified_summary.tsv")
 
     # Add an illegal merge to MergeInto
     summary_df.loc[cant_merge_echotime_dwi_row, "MergeInto"] = summary_df.ParamGroup[
@@ -929,6 +927,7 @@ def test_apply_tsv_changes(tmp_path):
         if "bold" in str(full_path):
             # Construct physio file paths by replacing the scan suffix with _physio
             from bids.layout import parse_file_entities
+
             old_suffix = parse_file_entities(str(full_path))["suffix"]
             old_ext = "".join(full_path.suffixes)
             scan_end = "_" + old_suffix + old_ext
@@ -1083,8 +1082,8 @@ def test_datalad_integration(tmp_path):
     edited_binary_content = file_hash(test_binary)
 
     # Check that the file content has changed
-    assert not original_content == edited_content
-    assert not original_binary_content == edited_binary_content
+    assert original_content != edited_content
+    assert original_binary_content != edited_binary_content
 
     # Check that datalad knows something has changed
     assert not uninit_cubids.is_datalad_clean()
@@ -1210,12 +1209,12 @@ def test_bids_version(tmp_path):
     min_validator_version = Version("2.0.0")
     min_schema_version = Version("0.11.3")
 
-    assert (
-        validator_version >= min_validator_version
-    ), f"Validator version {validator_version} is less than minimum {min_validator_version}"
-    assert (
-        schema_version >= min_schema_version
-    ), f"Schema version {schema_version} is less than minimum {min_schema_version}"
+    assert validator_version >= min_validator_version, (
+        f"Validator version {validator_version} is less than minimum {min_validator_version}"
+    )
+    assert schema_version >= min_schema_version, (
+        f"Schema version {schema_version} is less than minimum {min_schema_version}"
+    )
 
 
 # def test_image(image='pennlinc/bond:latest'):

--- a/cubids/tests/test_cli.py
+++ b/cubids/tests/test_cli.py
@@ -12,6 +12,7 @@ import json
 import shutil
 from functools import partial
 
+import pandas as pd
 import pytest
 
 from cubids.cli import _is_file, _main, _path_exists
@@ -153,6 +154,181 @@ def test_main_help(capsys):
     assert "CuBIDS commands" in captured.out
 
 
+def _create_date_time_shift_dataset(tmp_path):
+    """Create a small dataset containing all date/time metadata handled by the command."""
+    bids_dir = tmp_path / "date_time_shift_dataset"
+    scans_dir = bids_dir / "sub-01" / "ses-01"
+    later_scans_dir = bids_dir / "sub-01" / "ses-02"
+    sidecar_dir = scans_dir / "func"
+    scans_dir.mkdir(parents=True)
+    later_scans_dir.mkdir(parents=True)
+    sidecar_dir.mkdir()
+    (bids_dir / "dataset_description.json").write_text('{"Name": "test"}\n')
+    git_dir = bids_dir / ".git"
+    git_dir.mkdir()
+    (git_dir / "ignored.json").write_text("not BIDS metadata")
+
+    (scans_dir / "sub-01_ses-01_scans.tsv").write_text(
+        "filename\tacq_time\tnote\n"
+        "func/sub-01_task-rest_bold.nii.gz\t2024-01-10T13:43:04\tkeep\n"
+        "func/sub-01_task-other_bold.nii.gz\t2024-01-10T23:45:00\tkeep\n"
+        "func/sub-01_task-na_bold.nii.gz\tn/a\tkeep\n"
+        "func/sub-01_task-invalid_bold.nii.gz\tnot-a-date\tkeep\n"
+    )
+    (later_scans_dir / "sub-01_ses-02_scans.tsv").write_text(
+        "filename\tacq_time\tnote\nfunc/sub-01_task-rest_bold.nii.gz\t2024-01-24T09:12:20\tkeep\n"
+    )
+
+    acquisition_json = sidecar_dir / "sub-01_task-rest_bold.json"
+    acquisition_json.write_text(
+        json.dumps(
+            {
+                "AcquisitionTime": "23:30:00.123",
+                "RepetitionTime": 2.0,
+                "Nested": {"Unchanged": True},
+                "global": {
+                    "const": {
+                        "PerformedProcedureStepStartTime": "151258.640000",
+                        "SeriesTime": "154553.343000",
+                        "StudyTime": "151258.562000",
+                    }
+                },
+                "time": {
+                    "samples": {
+                        "AcquisitionTime": ["154550.195000", "152958.000000"],
+                        "ContentTime": ["154553.359000", "152958.000000"],
+                    }
+                },
+            }
+        )
+    )
+    untouched_json = sidecar_dir / "sub-01_task-other_bold.json"
+    untouched_json.write_text('{"RepetitionTime": 3.0}\n')
+    return bids_dir, acquisition_json, untouched_json
+
+
+def test_date_time_shift_command(tmp_path, caplog):
+    """Shift scans dates, round acquisition times, and retain unrelated metadata."""
+    bids_dir, acquisition_json, untouched_json = _create_date_time_shift_dataset(tmp_path)
+    untouched_contents = untouched_json.read_text()
+
+    assert _main(["date-time-shift", str(bids_dir), "--n-cpus", "2"]) == 0
+
+    first_table = pd.read_csv(
+        bids_dir / "sub-01" / "ses-01" / "sub-01_ses-01_scans.tsv",
+        sep="\t",
+        keep_default_na=False,
+    )
+    later_table = pd.read_csv(
+        bids_dir / "sub-01" / "ses-02" / "sub-01_ses-02_scans.tsv",
+        sep="\t",
+        keep_default_na=False,
+    )
+    assert first_table["acq_time"].tolist() == [
+        "1800-01-01T14:00:00",
+        "1800-01-02T00:00:00",
+        "n/a",
+        "not-a-date",
+    ]
+    assert later_table["acq_time"].tolist() == ["1800-01-15T09:00:00"]
+
+    metadata = json.loads(acquisition_json.read_text())
+    assert metadata == {
+        "AcquisitionTime": "00:00:00",
+        "RepetitionTime": 2.0,
+        "Nested": {"Unchanged": True},
+        "global": {
+            "const": {
+                "PerformedProcedureStepStartTime": "15:00:00",
+                "SeriesTime": "16:00:00",
+                "StudyTime": "15:00:00",
+            }
+        },
+        "time": {
+            "samples": {
+                "AcquisitionTime": ["16:00:00", "15:00:00"],
+                "ContentTime": ["16:00:00", "15:00:00"],
+            }
+        },
+    }
+    assert untouched_json.read_text() == untouched_contents
+    assert "Processed 2 scans.tsv files and 3 JSON files" in caplog.text
+    assert "Unparseable acq_time" in caplog.text
+
+
+def test_date_time_shift_includes_subject_level_scans_tables(tmp_path):
+    """Shift subject-level scans tables independently when no sessions exist."""
+    bids_dir = tmp_path / "cross_sectional_dataset"
+    (bids_dir / "dataset_description.json").parent.mkdir()
+    (bids_dir / "dataset_description.json").write_text('{"Name": "test"}\n')
+    scans_files = []
+    for subject, acquisition_time in (
+        ("sub-01", "2024-01-10T13:43:04"),
+        ("sub-02", "2024-02-10T13:43:04"),
+    ):
+        scans_file = bids_dir / subject / f"{subject}_scans.tsv"
+        scans_file.parent.mkdir()
+        scans_file.write_text(
+            f"filename\tacq_time\nfunc/{subject}_task-rest_bold.nii.gz\t{acquisition_time}\n"
+        )
+        scans_files.append(scans_file)
+
+    assert _main(["date-time-shift", str(bids_dir)]) == 0
+
+    for scans_file in scans_files:
+        scans_table = pd.read_csv(scans_file, sep="\t", keep_default_na=False)
+        assert scans_table["acq_time"].tolist() == ["1800-01-01T14:00:00"]
+
+
+def test_date_time_shift_dry_run_does_not_modify_files(tmp_path, caplog):
+    """Report planned date/time anonymization without writing to the dataset."""
+    bids_dir, acquisition_json, _ = _create_date_time_shift_dataset(tmp_path)
+    scans_file = bids_dir / "sub-01" / "ses-01" / "sub-01_ses-01_scans.tsv"
+    original_scans = scans_file.read_text()
+    original_json = acquisition_json.read_text()
+
+    assert _main(["date-time-shift", str(bids_dir), "--dry-run"]) == 0
+
+    assert scans_file.read_text() == original_scans
+    assert acquisition_json.read_text() == original_json
+    assert "WOULD CHANGE" in caplog.text
+    assert "Checked 2 scans.tsv files and 3 JSON files" in caplog.text
+
+
+def test_date_time_shift_validates_all_metadata_before_writing(tmp_path, caplog):
+    """Do not change valid metadata when another JSON file cannot be read."""
+    bids_dir, acquisition_json, _ = _create_date_time_shift_dataset(tmp_path)
+    scans_file = bids_dir / "sub-01" / "ses-01" / "sub-01_ses-01_scans.tsv"
+    original_scans = scans_file.read_text()
+    original_json = acquisition_json.read_text()
+    (bids_dir / "invalid.json").write_text("not valid JSON")
+
+    assert _main(["date-time-shift", str(bids_dir)]) == 1
+
+    assert scans_file.read_text() == original_scans
+    assert acquisition_json.read_text() == original_json
+    assert "validation failed; no files were modified" in caplog.text
+
+
+def test_date_time_shift_help_and_input_validation(tmp_path, capsys):
+    """Expose command help and reject a file path in place of a BIDS directory."""
+    with pytest.raises(SystemExit) as excinfo:
+        _main(["date-time-shift", "--help"])
+    assert excinfo.value.code == 0
+    help_output = capsys.readouterr().out
+    assert "before" in help_output
+    assert "DataLad" in help_output
+    assert "--n-cpus" in help_output
+
+    path_file = tmp_path / "not_a_directory"
+    path_file.touch()
+    with pytest.raises(SystemExit) as excinfo:
+        _main(["date-time-shift", str(path_file)])
+    assert excinfo.value.code == 2
+
+    assert _main(["date-time-shift", str(tmp_path), "--n-cpus", "0"]) == 2
+
+
 def test_validate_command(tmp_path):
     """Test the validate command."""
     # Create mock BIDS dataset
@@ -263,7 +439,17 @@ def test_validate_subject_scope_with_n_cpus(tmp_path, build_bids_dataset):
     output_prefix = tmp_path / "validation_parallel"
 
     # This should complete without error
-    _main(["validate", str(bids_dir), str(output_prefix), "--validation-scope", "subject", "--n-cpus", "1"])
+    _main(
+        [
+            "validate",
+            str(bids_dir),
+            str(output_prefix),
+            "--validation-scope",
+            "subject",
+            "--n-cpus",
+            "1",
+        ]
+    )
 
     # Verify the command completed successfully by checking if the output files exist
     assert (output_prefix.parent / f"{output_prefix.name}_validation.tsv").exists()
@@ -314,7 +500,9 @@ def test_add_nifti_info_command_with_test_dataset(tmp_path):
 
 def test_print_metadata_fields_command_with_test_dataset(tmp_path, capsys, build_bids_dataset):
     """Test the print-metadata-fields command with the test BIDS dataset."""
-    bids_dir = _build_cli_dataset(tmp_path, build_bids_dataset, dataset_name="metadata_fields_dataset")
+    bids_dir = _build_cli_dataset(
+        tmp_path, build_bids_dataset, dataset_name="metadata_fields_dataset"
+    )
 
     # Run print-metadata-fields
     _main(["print-metadata-fields", str(bids_dir)])
@@ -327,7 +515,9 @@ def test_print_metadata_fields_command_with_test_dataset(tmp_path, capsys, build
 
 def test_remove_metadata_fields_command_with_test_dataset(tmp_path, build_bids_dataset):
     """Test the remove-metadata-fields command with the test BIDS dataset."""
-    bids_dir = _build_cli_dataset(tmp_path, build_bids_dataset, dataset_name="remove_metadata_dataset")
+    bids_dir = _build_cli_dataset(
+        tmp_path, build_bids_dataset, dataset_name="remove_metadata_dataset"
+    )
 
     # Get a sample JSON sidecar
     json_file = next(bids_dir.rglob("*.json"))

--- a/cubids/tests/test_cli.py
+++ b/cubids/tests/test_cli.py
@@ -10,6 +10,7 @@ Each test case includes assertions to verify the expected behavior of the corres
 import argparse
 import json
 import shutil
+import stat
 from functools import partial
 
 import pandas as pd
@@ -278,6 +279,18 @@ def test_date_time_shift_includes_subject_level_scans_tables(tmp_path):
     for scans_file in scans_files:
         scans_table = pd.read_csv(scans_file, sep="\t", keep_default_na=False)
         assert scans_table["acq_time"].tolist() == ["1800-01-01T14:00:00"]
+
+
+def test_date_time_shift_makes_updated_files_writable(tmp_path, caplog):
+    """Add owner-write permission before updating a read-only metadata file."""
+    bids_dir, acquisition_json, _ = _create_date_time_shift_dataset(tmp_path)
+    acquisition_json.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+
+    assert _main(["date-time-shift", str(bids_dir)]) == 0
+
+    assert acquisition_json.stat().st_mode & stat.S_IWUSR
+    assert json.loads(acquisition_json.read_text())["AcquisitionTime"] == "00:00:00"
+    assert f"Made file writable: {acquisition_json}" in caplog.text
 
 
 def test_date_time_shift_dry_run_does_not_modify_files(tmp_path, caplog):

--- a/cubids/tests/test_cli.py
+++ b/cubids/tests/test_cli.py
@@ -177,7 +177,8 @@ def _create_date_time_shift_dataset(tmp_path):
         "func/sub-01_task-invalid_bold.nii.gz\tnot-a-date\tkeep\n"
     )
     (later_scans_dir / "sub-01_ses-02_scans.tsv").write_text(
-        "filename\tacq_time\tnote\nfunc/sub-01_task-rest_bold.nii.gz\t2024-01-24T09:12:20\tkeep\n"
+        "filename\tacq_time\tnote\n"
+        'func/sub-01_task-rest_bold.nii.gz\t2024-01-24T09:12:20\tsay "hi"\n'
     )
 
     acquisition_json = sidecar_dir / "sub-01_task-rest_bold.json"
@@ -185,13 +186,14 @@ def _create_date_time_shift_dataset(tmp_path):
         json.dumps(
             {
                 "AcquisitionTime": "23:30:00.123",
+                "AcquisitionDateTime": "2024-01-10T23:30:00",
                 "RepetitionTime": 2.0,
                 "Nested": {"Unchanged": True},
                 "global": {
                     "const": {
                         "PerformedProcedureStepStartTime": "151258.640000",
                         "SeriesTime": "154553.343000",
-                        "StudyTime": "151258.562000",
+                        "StudyTime": 91258.562,
                     }
                 },
                 "time": {
@@ -232,17 +234,21 @@ def test_date_time_shift_command(tmp_path, caplog):
         "not-a-date",
     ]
     assert later_table["acq_time"].tolist() == ["1800-01-15T09:00:00"]
+    # Quote characters in untouched columns survive the rewrite verbatim.
+    later_scans_file = bids_dir / "sub-01" / "ses-02" / "sub-01_ses-02_scans.tsv"
+    assert 'say "hi"' in later_scans_file.read_text()
 
     metadata = json.loads(acquisition_json.read_text())
     assert metadata == {
         "AcquisitionTime": "00:00:00",
+        "AcquisitionDateTime": "2024-01-10T23:30:00",
         "RepetitionTime": 2.0,
         "Nested": {"Unchanged": True},
         "global": {
             "const": {
                 "PerformedProcedureStepStartTime": "15:00:00",
                 "SeriesTime": "16:00:00",
-                "StudyTime": "15:00:00",
+                "StudyTime": "09:00:00",
             }
         },
         "time": {
@@ -255,6 +261,7 @@ def test_date_time_shift_command(tmp_path, caplog):
     assert untouched_json.read_text() == untouched_contents
     assert "Processed 2 scans.tsv files and 3 JSON files" in caplog.text
     assert "Unparseable acq_time" in caplog.text
+    assert "Date field AcquisitionDateTime is not de-identified" in caplog.text
 
 
 def test_date_time_shift_includes_subject_level_scans_tables(tmp_path):
@@ -279,6 +286,20 @@ def test_date_time_shift_includes_subject_level_scans_tables(tmp_path):
     for scans_file in scans_files:
         scans_table = pd.read_csv(scans_file, sep="\t", keep_default_na=False)
         assert scans_table["acq_time"].tolist() == ["1800-01-01T14:00:00"]
+
+
+def test_date_time_shift_warns_for_subject_without_parseable_dates(tmp_path, caplog):
+    """Warn about unparseable acq_time values even when a subject has no valid dates."""
+    bids_dir = tmp_path / "unparseable_dataset"
+    scans_file = bids_dir / "sub-01" / "sub-01_scans.tsv"
+    scans_file.parent.mkdir(parents=True)
+    scans_file.write_text("filename\tacq_time\nfunc/sub-01_task-rest_bold.nii.gz\tJan 10 2024\n")
+    original_scans = scans_file.read_text()
+
+    assert _main(["date-time-shift", str(bids_dir)]) == 0
+
+    assert "Unparseable acq_time" in caplog.text
+    assert scans_file.read_text() == original_scans
 
 
 def test_date_time_shift_makes_updated_files_writable(tmp_path, caplog):

--- a/cubids/tests/test_utils.py
+++ b/cubids/tests/test_utils.py
@@ -9,13 +9,18 @@ from cubids.tests.utils import compare_group_assignments
 
 
 def test_find_json_files_excludes_git_metadata(tmp_path):
-    """Find JSON files in a dataset without traversing its Git metadata."""
+    """Find JSON files in a dataset without traversing hidden paths like Git metadata."""
     dataset_json = tmp_path / "sub-01" / "metadata.json"
     dataset_json.parent.mkdir()
     dataset_json.write_text("{}")
     (tmp_path / "dataset_description.json").write_text("{}")
     (tmp_path / ".git").mkdir()
     (tmp_path / ".git" / "ignored.json").write_text("{}")
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "config.json").write_text("{}")
+    (tmp_path / ".datalad").mkdir()
+    (tmp_path / ".datalad" / "config.json").write_text("{}")
+    (tmp_path / ".hidden.json").write_text("{}")
     (tmp_path / "directory.json").mkdir()
 
     assert utils.find_json_files(tmp_path) == [

--- a/cubids/tests/test_utils.py
+++ b/cubids/tests/test_utils.py
@@ -8,6 +8,22 @@ from cubids.cubids import CuBIDS
 from cubids.tests.utils import compare_group_assignments
 
 
+def test_find_json_files_excludes_git_metadata(tmp_path):
+    """Find JSON files in a dataset without traversing its Git metadata."""
+    dataset_json = tmp_path / "sub-01" / "metadata.json"
+    dataset_json.parent.mkdir()
+    dataset_json.write_text("{}")
+    (tmp_path / "dataset_description.json").write_text("{}")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.json").write_text("{}")
+    (tmp_path / "directory.json").mkdir()
+
+    assert utils.find_json_files(tmp_path) == [
+        tmp_path / "dataset_description.json",
+        dataset_json,
+    ]
+
+
 def test_round_params():
     """Test the cubids.utils.round_params function."""
     # Example DataFrame
@@ -155,7 +171,6 @@ def test_cluster_single_parameters():
         out_df["Cluster_ImageType"].values.astype(int),
         [0, 0, 0, 0, 0, 0, 1, 2],
     )
-
 
     # Change the tolerance for SliceTiming
     config["sidecar_params"]["func"]["SliceTiming"]["tolerance"] = 0.5

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -113,6 +113,13 @@ def _update_json(json_file, metadata):
         json.dump(metadata, f, ensure_ascii=False, indent=4)
 
 
+def find_json_files(root):
+    """Return regular JSON files below ``root``, excluding Git metadata."""
+    return sorted(
+        path for path in Path(root).rglob("*.json") if path.is_file() and ".git" not in path.parts
+    )
+
+
 def _entity_set_to_entities(entity_set):
     """Split an entity_set name into a pybids dictionary of entities.
 
@@ -615,7 +622,7 @@ def cluster_single_parameters(df, config, modality):
                         # clustering requires at least two samples
                         array[np.isnan(array)] = -999
 
-                        tolerance = to_format[column_name]["tolerance"]
+                        tolerance = column_fmt["tolerance"]
                         clustering = AgglomerativeClustering(
                             n_clusters=None,
                             distance_threshold=tolerance,
@@ -638,7 +645,7 @@ def cluster_single_parameters(df, config, modality):
 
                 if valid_mask.sum() > 1:  # Proceed with clustering only if >1 valid value
                     valid_array = array[valid_mask].reshape(-1, 1)
-                    tolerance = to_format[column_name]["tolerance"]
+                    tolerance = column_fmt["tolerance"]
 
                     clustering = AgglomerativeClustering(
                         n_clusters=None,
@@ -987,7 +994,7 @@ def build_path(filepath, out_entities, out_dir, schema, is_longitudinal):
 
     # Add leading zeros to run entity if it's an integer.
     # If it's a string, respect the value provided.
-    if "run" in file_entities.keys() and isinstance(file_entities["run"], int):
+    if "run" in file_entities and isinstance(file_entities["run"], int):
         # Infer the number of leading zeros needed from the original filename
         n_leading = 2  # default to 1 leading zero
         if "_run-" in filepath:
@@ -1094,7 +1101,7 @@ def assign_variants(summary, rename_cols):
             for col in rename_cols:
                 dom_entity_set = dom_dict[entity_set]
 
-                if f"Cluster_{col}" in dom_entity_set.keys():
+                if f"Cluster_{col}" in dom_entity_set:
                     cluster_val = summary.loc[row, f"Cluster_{col}"]
                     if pd.isna(cluster_val):
                         # This should only occur when the entity set does not have the
@@ -1131,9 +1138,7 @@ def assign_variants(summary, rename_cols):
                         elif isinstance(val, float):
                             val = str(val).replace(".", "p")
 
-                        if val.endswith("p0"):
-                            # Remove the trailing "p0"
-                            val = val[:-2]
+                        val = val.removesuffix("p0")
 
                         # Filter out non-alphanumeric characters
                         val = re.sub(r"[^a-zA-Z0-9]", "", val)
@@ -1143,7 +1148,7 @@ def assign_variants(summary, rename_cols):
             if acq_str == "VARIANT":
                 acq_str += "Other"
 
-            if "acquisition" in entities.keys():
+            if "acquisition" in entities:
                 acq = f"acquisition-{entities['acquisition'] + acq_str}"
                 new_name = summary.loc[row, "EntitySet"].replace(
                     f"acquisition-{entities['acquisition']}", acq
@@ -1203,7 +1208,7 @@ def collect_file_collections(layout, base_file):
     }
 
     base_file = layout.get_file(base_file)
-    fc_query = {ent: [Query.ANY, Query.NONE] for ent in file_collection_entities.keys()}
+    fc_query = {ent: [Query.ANY, Query.NONE] for ent in file_collection_entities}
     query = base_file.get_entities()
     query = {**query, **fc_query}
     files = layout.get(**query)

--- a/cubids/utils.py
+++ b/cubids/utils.py
@@ -114,9 +114,17 @@ def _update_json(json_file, metadata):
 
 
 def find_json_files(root):
-    """Return regular JSON files below ``root``, excluding Git metadata."""
+    """Return regular JSON files below ``root``, excluding hidden paths like ``.git``.
+
+    BIDS ignores hidden files and directories, so anything below a dot-prefixed
+    path component (``.git``, ``.github``, ``.datalad``, ...) is skipped.
+    """
+    root = Path(root)
     return sorted(
-        path for path in Path(root).rglob("*.json") if path.is_file() and ".git" not in path.parts
+        path
+        for path in root.rglob("*.json")
+        if path.is_file()
+        and not any(part.startswith(".") for part in path.relative_to(root).parts)
     )
 
 

--- a/cubids/validator.py
+++ b/cubids/validator.py
@@ -81,7 +81,7 @@ def get_bids_validator_version():
         Version of the BIDS validator.
     """
     command = ["deno", "run", "-A", "jsr:@bids/validator", "--version"]
-    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run(command, capture_output=True)
     output = result.stdout.decode("utf-8").strip()
     version = output.split()[-1]
     # Remove ANSI color codes
@@ -185,7 +185,7 @@ def run_validator(call):
     #     logger.info("Running the validator with call:")
     #     logger.info('\"' + ' '.join(call) + '\"')
 
-    ret = subprocess.run(call, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    ret = subprocess.run(call, capture_output=True)
     return ret
 
 

--- a/cubids/workflows.py
+++ b/cubids/workflows.py
@@ -15,6 +15,7 @@ import pandas as pd
 import tqdm
 
 from cubids.cubids import CuBIDS
+from cubids.date_time_shift import date_time_shift as _date_time_shift
 from cubids.metadata_merge import merge_json_into_json
 from cubids.validator import (
     bids_validator_version,
@@ -322,7 +323,14 @@ def validate(
 
         # Prepare arguments for each subject
         validation_args = [
-            (subject, files_list, bids_dir_str, ignore_nifti_headers, local_validator, schema_str)
+            (
+                subject,
+                files_list,
+                bids_dir_str,
+                ignore_nifti_headers,
+                local_validator,
+                schema_str,
+            )
             for subject, files_list in subjects_dict.items()
         ]
 
@@ -388,6 +396,26 @@ def validate(
             return parsed
 
 
+def date_time_shift(bids_dir, dry_run=False, n_cpus=1):
+    """De-identify BIDS acquisition dates and round acquisition times.
+
+    Parameters
+    ----------
+    bids_dir : :obj:`pathlib.Path`
+        Root of the BIDS dataset to process.
+    dry_run : :obj:`bool`
+        Report planned changes without writing files.
+    n_cpus : :obj:`int`
+        Number of workers used to read and plan independent file updates.
+
+    Returns
+    -------
+    int
+        Exit status returned by the date/time-shift workflow.
+    """
+    return _date_time_shift(bids_dir=bids_dir, dry_run=dry_run, n_cpus=n_cpus)
+
+
 def bids_version(bids_dir, write=False, schema=None):
     """Get BIDS validator and schema version.
 
@@ -415,8 +443,8 @@ def bids_version(bids_dir, write=False, schema=None):
         subject = sub_folders[0]
     except FileNotFoundError:
         raise FileNotFoundError(f"The directory {bids_dir} does not exist.")
-    except ValueError as ve:
-        raise ve
+    except ValueError:
+        raise
 
     # build a dictionary with {SubjectLabel: [List of files]}
     # run first subject only
@@ -531,9 +559,8 @@ def apply(
         grouping_config=config,
         schema_json=schema,
     )
-    if use_datalad:
-        if not bod.is_datalad_clean():
-            raise Exception("Untracked change in " + str(bids_dir))
+    if use_datalad and not bod.is_datalad_clean():
+        raise Exception("Untracked change in " + str(bids_dir))
     bod.apply_tsv_changes(
         str(edited_summary_tsv),
         str(files_tsv),
@@ -599,11 +626,10 @@ def copy_exemplars(
     """
     # Run directly from python using
     bod = CuBIDS(data_root=str(bids_dir), use_datalad=use_datalad, force_unlock=force_unlock)
-    if use_datalad:
-        if not bod.is_datalad_clean():
-            raise Exception(
-                "Untracked changes. Need to save " + str(bids_dir) + " before coyping exemplars"
-            )
+    if use_datalad and not bod.is_datalad_clean():
+        raise Exception(
+            "Untracked changes. Need to save " + str(bids_dir) + " before coyping exemplars"
+        )
     bod.copy_exemplars(
         str(exemplars_dir),
         str(exemplars_tsv),
@@ -634,9 +660,8 @@ def add_nifti_info(bids_dir, use_datalad, force_unlock, n_cpus=1):
         use_datalad=use_datalad,
         force_unlock=force_unlock,
     )
-    if use_datalad:
-        if not bod.is_datalad_clean():
-            raise Exception("Untracked change in " + str(bids_dir))
+    if use_datalad and not bod.is_datalad_clean():
+        raise Exception("Untracked change in " + str(bids_dir))
         # if bod.is_datalad_clean() and not force_unlock:
         #     raise Exception("Need to unlock " + str(bids_dir))
     bod.add_nifti_info(n_cpus=n_cpus)
@@ -679,9 +704,8 @@ def purge(bids_dir, use_datalad, scans, n_cpus=1):
     """
     # Run directly from python using
     bod = CuBIDS(data_root=str(bids_dir), use_datalad=use_datalad)
-    if use_datalad:
-        if not bod.is_datalad_clean():
-            raise Exception("Untracked change in " + str(bids_dir))
+    if use_datalad and not bod.is_datalad_clean():
+        raise Exception("Untracked change in " + str(bids_dir))
     bod.purge(str(scans), n_cpus=n_cpus)
 
 

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -66,11 +66,35 @@ To remove the `PatientName` field from the sidecars, we can use the command:
 
 This command should succeed silently.
 
+Before placing the dataset under version control, we also de-identify its
+acquisition dates and reduce the precision of acquisition times. We first
+review the planned changes without modifying the dataset:
+
+.. code-block:: console
+
+    $ cubids date-time-shift BIDS_Dataset --dry-run
+
+After confirming the output, apply the changes:
+
+.. code-block:: console
+
+    $ cubids date-time-shift BIDS_Dataset
+
+This sets each subject's earliest rounded acquisition date in subject-level or
+session-level ``*_scans.tsv`` files to ``1800-01-01``, preserves the
+calendar-day intervals between acquisitions, and rounds ``acq_time`` plus JSON
+``AcquisitionTime`` fields to the nearest hour. This includes dcmmeta-derived values in
+``time.samples`` and ``global.const``. This must occur before the first DataLad
+commit so that identifiable dates and precise acquisition times are never
+stored in the dataset history. For a large dataset, add ``--n-cpus 4`` to read
+and plan updates in parallel.
+
 
 Checking the BIDS dataset into DataLad
 --------------------------------------
 
-Now that all PHI has been removed from the metadata, we are ready to check our dataset into ``datalad``.
+Now that PHI has been removed from the metadata and acquisition times have been
+de-identified, we are ready to check our dataset into ``datalad``.
 To do this, we run the following command:
 
 .. code-block:: console

--- a/docs/sphinxext/github_link.py
+++ b/docs/sphinxext/github_link.py
@@ -87,6 +87,4 @@ def make_linkcode_resolve(package, url_fmt):
                                    '{path}#L{lineno}')
     """
     revision = _get_git_revision()
-    return partial(
-        _linkcode_resolve, revision=revision, package=package, url_fmt=url_fmt
-    )
+    return partial(_linkcode_resolve, revision=revision, package=package, url_fmt=url_fmt)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,49 @@ that differ in a set of important acquisition parameters.
 The subsets of consistent acquisition parameter sets within a Entity Set are called a :ref:`paramgroup`.
 
 
+Date/time anonymization before DataLad
+--------------------------------------
+
+Run ``cubids date-time-shift`` before your BIDS dataset is checked into DataLad. The command updates acquisition metadata in
+place, so running it before the first DataLad commit prevents identifiable dates
+and precise acquisition times from being recorded in the dataset history.
+
+Start with a dry run:
+
+.. code-block:: console
+
+    $ cubids date-time-shift /path/to/bids --dry-run
+
+To apply the anonymization, run:
+
+.. code-block:: console
+
+    $ cubids date-time-shift /path/to/bids
+
+For larger datasets, use ``--n-cpus`` to read and plan independent file
+updates in parallel. Files are still written only after the preflight phase
+has completed successfully:
+
+.. code-block:: console
+
+    $ cubids date-time-shift /path/to/bids --n-cpus 4
+
+For each subject, CuBIDS sets the earliest rounded acquisition date in
+subject-level or session-level ``*_scans.tsv`` files to ``1800-01-01`` and
+preserves calendar-day intervals between acquisitions. It rounds ``acq_time``
+values in those tables and the following JSON fields to the nearest hour:
+``AcquisitionTime``,
+``time.samples.AcquisitionTime``, ``time.samples.ContentTime``,
+``global.const.PerformedProcedureStepStartTime``, ``global.const.SeriesTime``,
+and ``global.const.StudyTime``. Thirty minutes rounds up, and times at 23:30 or
+later wrap to ``00:00:00``. No other metadata values are changed.
+
+The command validates all readable scans tables and JSON files before writing any
+changes. It reports unparseable acquisition-time values as warnings and leaves
+those individual values unchanged. Use ``--dry-run`` to review every planned
+change before running the command without that option.
+
+
 .. _paramgroup:
 
 Parameter Group

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -74,6 +74,12 @@ values in those tables and the following JSON fields to the nearest hour:
 and ``global.const.StudyTime``. Thirty minutes rounds up, and times at 23:30 or
 later wrap to ``00:00:00``. No other metadata values are changed.
 
+Date-bearing JSON fields such as ``AcquisitionDateTime`` and the dcmmeta
+``global.const`` date fields (``StudyDate``, ``SeriesDate``, ``AcquisitionDate``,
+``ContentDate``) are not rewritten; the command reports them as warnings so
+they can be removed or de-identified before the dataset enters version
+control.
+
 The command validates all readable scans tables and JSON files before writing any
 changes. It reports unparseable acquisition-time values as warnings and leaves
 those individual values unchanged. Use ``--dry-run`` to review every planned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,12 @@ classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Image Recognition",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "datalad>=0.13.5,!=0.17.3,!=0.17.0,!=0.16.1",
     "numpy<=2.2.6",
@@ -112,14 +111,14 @@ version-file = "cubids/_version.py"
 
 [tool.ruff]
 line-length = 99
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]
 
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py311']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,13 @@ version-file = "cubids/_version.py"
 # Developer tool configurations
 #
 
+[tool.ruff]
+line-length = 99
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.black]
 line-length = 99
 target-version = ['py38']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ version-file = "cubids/_version.py"
 
 [tool.ruff]
 line-length = 99
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
Adds `cubids date-time-shift` for pre-DataLad date/time de-identification.
- Shifts each subject’s earliest rounded acq_time date to 1800-01-01.
- Preserves day offsets, rounds to the nearest hour, and supports both subject- and session-level `*_scans.tsv`.
- Rounds supported sidecar and dcmmeta JSON time fields.
- Provides --dry-run and --n-cpus; validates all inputs before writing.